### PR TITLE
multi_efficiency_parts

### DIFF
--- a/Source/KolonyTools/KolonyTools/MKSModule.cs
+++ b/Source/KolonyTools/KolonyTools/MKSModule.cs
@@ -138,34 +138,7 @@ namespace KolonyTools
 
                 print("effpartname: " + efficiencyPart);
                 //Add in efficiencyParts 
-                if (efficiencyPart != "")
-                {
-                    var genParts = vessel.Parts.Count(p => p.name == part.name);
-                    var effPartList = vessel.Parts.Where(p => p.name == (efficiencyPart.Replace('_','.')));
-                    var effParts = 0;
-
-                    foreach (var ep in effPartList)
-                    {
-                        var mod = ep.FindModuleImplementing<USIAnimation>();
-                        if (mod == null)
-                        {
-                            effParts++;
-                        }
-                        else
-                        {
-                            if (mod.isDeployed)
-                                effParts++;
-                        };
-                    }
-
-                    effParts = (effParts - genParts) / genParts;
-                    print("effParts: " + effParts);
-                    print("oldEff: " + eff);
-                    eff += effParts;
-                    print("newEff: " + eff); 
-                    if (eff < 0.25)  
-                        eff = 0.25f;  //We can go as low as 25% as these are almost mandatory.
-                }
+                eff += GetTotalEfficiencyParts(efficiencyPart);
 
                 if (!calculateEfficiency)
                 {
@@ -190,6 +163,52 @@ namespace KolonyTools
             }
         }
 
+
+        private float GetTotalEfficiencyParts(string efficiencyPart)
+        {
+            float eff = 0;
+
+            if (efficiencyPart != "")
+            {
+                char[] delimeters = { ';' };
+                var efficiencyParts = efficiencyPart.Split(delimeters);
+
+                var genParts = vessel.Parts.Count(p => p.name == part.name);
+                var effParts = 0;
+
+                //If multiple efficiency parts are listed, each type contributes to the total.
+                //Count up the total number of parts from the allowed types.
+                foreach (var efficiencyPartType in efficiencyParts)
+                {
+                    var effPartList = vessel.Parts.Where(p => p.name == (efficiencyPartType.Replace('_', '.')));
+
+                    foreach (var ep in effPartList)
+                    {
+                        var mod = ep.FindModuleImplementing<USIAnimation>();
+                        if (mod == null)
+                        {
+                            effParts++;
+                        }
+                        else
+                        {
+                            if (mod.isDeployed)
+                                effParts++;
+                        };
+                    }
+                }
+
+                effParts = (effParts - genParts) / genParts;
+                print("effParts: " + effParts);
+                eff += effParts;
+                print("part efficiency: " + eff);
+
+                if (eff < 0.25)
+                    eff = 0.25f;  //We can go as low as 25% as these are almost mandatory.
+            }
+
+
+            return eff;
+        }
 
         private float GetCrewHappiness()
         {

--- a/Source/KolonyTools/KolonyTools/MKSModule.cs
+++ b/Source/KolonyTools/KolonyTools/MKSModule.cs
@@ -138,7 +138,17 @@ namespace KolonyTools
 
                 print("effpartname: " + efficiencyPart);
                 //Add in efficiencyParts 
-                eff += GetTotalEfficiencyParts(efficiencyPart);
+                if (efficiencyPart != "")
+                {
+                    print("Current Efficiency: " + eff);
+
+                    eff += GetTotalEfficiencyParts(efficiencyPart);
+
+                    if (eff < 0.25)
+                        eff = 0.25f;  //We can go as low as 25% as these are almost mandatory.
+
+                    print("Efficiency after accounting for efficiency parts: " + eff);
+                }
 
                 if (!calculateEfficiency)
                 {
@@ -168,44 +178,36 @@ namespace KolonyTools
         {
             float eff = 0;
 
-            if (efficiencyPart != "")
-            {
-                char[] delimeters = { ';' };
-                var efficiencyParts = efficiencyPart.Split(delimeters);
+            char[] delimeters = { ';' };
+            var efficiencyParts = efficiencyPart.Split(delimeters);
 
+            //If multiple efficiency parts are listed, each type contributes to the total.
+            //Count up the total number of parts from the allowed types.
+            foreach (var efficiencyPartType in efficiencyParts)
+            {
                 var genParts = vessel.Parts.Count(p => p.name == part.name);
                 var effParts = 0;
+                var effPartList = vessel.Parts.Where(p => p.name == (efficiencyPartType.Replace('_', '.')));
 
-                //If multiple efficiency parts are listed, each type contributes to the total.
-                //Count up the total number of parts from the allowed types.
-                foreach (var efficiencyPartType in efficiencyParts)
+                foreach (var ep in effPartList)
                 {
-                    var effPartList = vessel.Parts.Where(p => p.name == (efficiencyPartType.Replace('_', '.')));
-
-                    foreach (var ep in effPartList)
+                    var mod = ep.FindModuleImplementing<USIAnimation>();
+                    if (mod == null)
                     {
-                        var mod = ep.FindModuleImplementing<USIAnimation>();
-                        if (mod == null)
-                        {
-                            effParts++;
-                        }
-                        else
-                        {
-                            if (mod.isDeployed)
-                                effParts++;
-                        };
+                        effParts++;
                     }
+                    else
+                    {
+                        if (mod.isDeployed)
+                            effParts++;
+                    };
                 }
 
                 effParts = (effParts - genParts) / genParts;
                 print("effParts: " + effParts);
                 eff += effParts;
                 print("part efficiency: " + eff);
-
-                if (eff < 0.25)
-                    eff = 0.25f;  //We can go as low as 25% as these are almost mandatory.
             }
-
 
             return eff;
         }


### PR DESCRIPTION
Adds support for multiple efficiency parts. part efficiency can now
accept more than one type of part at a time. Parts are separated by semicolon.
Example: efficiencyPart = MKS_HabDome;OKS_HabRing;WBI_IMEM
This allows for situations where, for example, the same Kolony module can be used in orbit or on the ground, but with efficiency parts built specifically for space or ground environments.

Testing done:
- no efficiency parts
- one efficiency part
- two parts of the same type
- three different efficiency parts