### PR TITLE
Allow SpareParts to be pumped around like other Part types

### DIFF
--- a/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/GameData/CommunityResourcePack/CommonResources.cfg
@@ -359,8 +359,8 @@ RESOURCE_DEFINITION
 {
    name = SpareParts
    density = 0.0189
-   flowMode = NO_FLOW
-   transfer = NONE
+   flowMode = ALL_VESSEL
+   transfer = PUMP
    isTweakable = true
    unitCost = 63
 }


### PR DESCRIPTION
This will let spare parts be pumped around like the other Part types in MKS