### PR TITLE
Updated Storage for KIS

### DIFF
--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MK3_Fabricator.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MK3_Fabricator.cfg
@@ -54,7 +54,7 @@ PART
 	MODULE
 	{
 		name = ModuleKISInventory
-		maxVolume = 50
+		maxVolume = 6500
 		externalAccess = true
 		internalAccess = false
 		slotsX = 10

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MK3_FuelRefinery.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MK3_FuelRefinery.cfg
@@ -54,7 +54,7 @@ PART
 	MODULE
 	{
 		name = ModuleKISInventory
-		maxVolume = 50
+		maxVolume = 6500
 		externalAccess = true
 		internalAccess = false
 		slotsX = 10

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MK3_Refinery.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MK3_Refinery.cfg
@@ -55,7 +55,7 @@ PART
 	MODULE
 	{
 		name = ModuleKISInventory
-		maxVolume = 50
+		maxVolume = 6500
 		externalAccess = true
 		internalAccess = false
 		slotsX = 10

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_AgModule.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_AgModule.cfg
@@ -53,7 +53,7 @@ PART
         editorItemsCategory = false
         moveSndPath = KIS/Sounds/itemMove
         equipable = false
-        equipMode = model
+        equipMode = physic
         equipSlot = <null>
         equipSkill = <null>
         equipRemoveHelmet = false

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_AgModule.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_AgModule.cfg
@@ -53,9 +53,9 @@ PART
         editorItemsCategory = false
         moveSndPath = KIS/Sounds/itemMove
         equipable = false
-        equipMode = physic
-        equipSlot = <null>
-        equipSkill = <null>
+        equipMode = part
+        equipSlot = Back Pocket
+        equipSkill = 
         equipRemoveHelmet = false
         equipMeshName = helmet
         equipBoneName = helmet01

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_AgModule.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_AgModule.cfg
@@ -40,16 +40,31 @@ PART
 	breakingTorque = 50
 
 	MODULE
-	{
-		name = KASModuleGrab            
-		evaPartPos = (0.0, 0.40, 0.00)        
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize  = 20
-		attachOnPart = true
-		attachOnEva = true
-	}
-
+{
+        name = ModuleKISItem
+        shortcutKeyAction = drop
+        useName = use
+        usableFromEva = true
+        usableFromContainer = true
+        usableFromPod = true
+        usableFromEditor = true
+        stackable = false
+        volumeOverride = 2500
+        editorItemsCategory = false
+        moveSndPath = KIS/Sounds/itemMove
+        equipable = false
+        equipMode = model
+        equipSlot = <null>
+        equipSkill = <null>
+        equipRemoveHelmet = false
+        equipMeshName = helmet
+        equipBoneName = helmet01
+        equipPos = (0, 0, 0)
+        equipDir = (0, 0, 0)
+        carriable = true
+        allowAttachOnStatic = false
+}
+as
 	MODULE
 	{
 		name = USIAnimation

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_DockingPort.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_DockingPort.cfg
@@ -77,4 +77,29 @@ PART
 		passable = true
 		passableWhenSurfaceAttached = true 
 	}
+	MODULE
+	{
+        name = ModuleKISItem
+        shortcutKeyAction = drop
+        useName = use
+        usableFromEva = true
+        usableFromContainer = true
+        usableFromPod = true
+        usableFromEditor = true
+        stackable = false
+        volumeOverride = 700
+        editorItemsCategory = false
+        moveSndPath = KIS/Sounds/itemMove
+        equipable = false
+        equipMode = model
+        equipSlot = <null>
+        equipSkill = <null>
+        equipRemoveHelmet = false
+        equipMeshName = helmet
+        equipBoneName = helmet01
+        equipPos = (0, 0, 0)
+        equipDir = (0, 0, 0)
+        carriable = true
+        allowAttachOnStatic = false
+	}
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_DockingPort.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_DockingPort.cfg
@@ -35,13 +35,28 @@ PART
 
 	MODULE
 	{
-		name = KASModuleGrab            
-		evaPartPos = (0.0, 0.40, -0.40)        
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize  = 20
-		attachOnPart = true
-		attachOnEva = true
+        name = ModuleKISItem
+        shortcutKeyAction = drop
+        useName = use
+        usableFromEva = true
+        usableFromContainer = true
+        usableFromPod = true
+        usableFromEditor = true
+        stackable = false
+        volumeOverride = 800
+        editorItemsCategory = false
+        moveSndPath = KIS/Sounds/itemMove
+        equipable = false
+        equipMode = part
+        equipSlot = Back Pocket
+        equipSkill = 
+        equipRemoveHelmet = false
+        equipMeshName = helmet
+        equipBoneName = helmet01
+        equipPos = (0, 0, 0)
+        equipDir = (0, 0, 0)
+        carriable = true
+        allowAttachOnStatic = false
 	}
 
 	MODULE

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube2.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube2.cfg
@@ -43,13 +43,28 @@ PART
 
 	MODULE
 	{
-		name = KASModuleGrab            
-		evaPartPos = (0.0, 0.40, 0.00)        
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize  = 20
-		attachOnPart = true
-		attachOnEva = true
+        name = ModuleKISItem
+        shortcutKeyAction = drop
+        useName = use
+        usableFromEva = true
+        usableFromContainer = true
+        usableFromPod = true
+        usableFromEditor = true
+        stackable = false
+        volumeOverride = 800
+        editorItemsCategory = false
+        moveSndPath = KIS/Sounds/itemMove
+        equipable = false
+        equipMode = physic
+        equipSlot = <null>
+        equipSkill = <null>
+        equipRemoveHelmet = false
+        equipMeshName = helmet
+        equipBoneName = helmet01
+        equipPos = (0, 0, 0)
+        equipDir = (0, 0, 0)
+        carriable = true
+        allowAttachOnStatic = false
 	}
 
 	MODULE

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube2.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube2.cfg
@@ -55,9 +55,9 @@ PART
         editorItemsCategory = false
         moveSndPath = KIS/Sounds/itemMove
         equipable = false
-        equipMode = physic
-        equipSlot = <null>
-        equipSkill = <null>
+        equipMode = part
+        equipSlot = Back Pocket
+        equipSkill = 
         equipRemoveHelmet = false
         equipMeshName = helmet
         equipBoneName = helmet01

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube4.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube4.cfg
@@ -43,13 +43,28 @@ PART
 
 	MODULE
 	{
-		name = KASModuleGrab            
-		evaPartPos = (0.0, 0.40, 0.00)        
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize  = 20
-		attachOnPart = true
-		attachOnEva = true
+        name = ModuleKISItem
+        shortcutKeyAction = drop
+        useName = use
+        usableFromEva = true
+        usableFromContainer = true
+        usableFromPod = true
+        usableFromEditor = true
+        stackable = false
+        volumeOverride = 1000
+        editorItemsCategory = false
+        moveSndPath = KIS/Sounds/itemMove
+        equipable = false
+        equipMode = physic
+        equipSlot = <null>
+        equipSkill = <null>
+        equipRemoveHelmet = false
+        equipMeshName = helmet
+        equipBoneName = helmet01
+        equipPos = (0, 0, 0)
+        equipDir = (0, 0, 0)
+        carriable = true
+        allowAttachOnStatic = false
 	}
 
 	MODULE

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube4.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube4.cfg
@@ -55,9 +55,9 @@ PART
         editorItemsCategory = false
         moveSndPath = KIS/Sounds/itemMove
         equipable = false
-        equipMode = physic
-        equipSlot = <null>
-        equipSkill = <null>
+        equipMode = part
+        equipSlot = Back Pocket
+        equipSkill = 
         equipRemoveHelmet = false
         equipMeshName = helmet
         equipBoneName = helmet01

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube8.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube8.cfg
@@ -55,9 +55,9 @@ PART
         editorItemsCategory = false
         moveSndPath = KIS/Sounds/itemMove
         equipable = false
-        equipMode = physic
-        equipSlot = <null>
-        equipSkill = <null>
+        equipMode = part
+        equipSlot = Back Pocket
+        equipSkill = 
         equipRemoveHelmet = false
         equipMeshName = helmet
         equipBoneName = helmet01

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube8.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ExpandoTube8.cfg
@@ -43,13 +43,28 @@ PART
 
 	MODULE
 	{
-		name = KASModuleGrab            
-		evaPartPos = (0.0, 0.40, 0.00)        
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize  = 20
-		attachOnPart = true
-		attachOnEva = true
+        name = ModuleKISItem
+        shortcutKeyAction = drop
+        useName = use
+        usableFromEva = true
+        usableFromContainer = true
+        usableFromPod = true
+        usableFromEditor = true
+        stackable = false
+        volumeOverride = 1200
+        editorItemsCategory = false
+        moveSndPath = KIS/Sounds/itemMove
+        equipable = false
+        equipMode = physic
+        equipSlot = <null>
+        equipSkill = <null>
+        equipRemoveHelmet = false
+        equipMeshName = helmet
+        equipBoneName = helmet01
+        equipPos = (0, 0, 0)
+        equipDir = (0, 0, 0)
+        carriable = true
+        allowAttachOnStatic = false
 	}
 
 	MODULE

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_FlexOTube.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_FlexOTube.cfg
@@ -56,13 +56,28 @@ PART
 
 	MODULE
 	{
-		name = KASModuleGrab            
-		evaPartPos = (0.0, 0.40, -0.3)        
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize  = 20
-		attachOnPart = true
-		attachOnEva = true
+        name = ModuleKISItem
+        shortcutKeyAction = drop
+        useName = use
+        usableFromEva = true
+        usableFromContainer = true
+        usableFromPod = true
+        usableFromEditor = true
+        stackable = true
+        volumeOverride = 700
+        editorItemsCategory = false
+        moveSndPath = KIS/Sounds/itemMove
+        equipable = false
+        equipMode = model
+        equipSlot = <null>
+        equipSkill = <null>
+        equipRemoveHelmet = false
+        equipMeshName = helmet
+        equipBoneName = helmet01
+        equipPos = (0, 0, 0)
+        equipDir = (0, 0, 0)
+        carriable = true
+        allowAttachOnStatic = false
 	}
 
 	MODULE

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_HabDome.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_HabDome.cfg
@@ -53,7 +53,7 @@ PART
         editorItemsCategory = false
         moveSndPath = KIS/Sounds/itemMove
         equipable = false
-        equipMode = model
+        equipMode = physic
         equipSlot = <null>
         equipSkill = <null>
         equipRemoveHelmet = false

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_HabDome.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_HabDome.cfg
@@ -53,9 +53,9 @@ PART
         editorItemsCategory = false
         moveSndPath = KIS/Sounds/itemMove
         equipable = false
-        equipMode = physic
-        equipSlot = <null>
-        equipSkill = <null>
+        equipMode = part
+        equipSlot = Back Pocket
+        equipSkill = 
         equipRemoveHelmet = false
         equipMeshName = helmet
         equipBoneName = helmet01

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_HabDome.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_HabDome.cfg
@@ -39,16 +39,31 @@ PART
 	breakingForce = 50
 	breakingTorque = 50
 
-	MODULE
-	{
-		name = KASModuleGrab            
-		evaPartPos = (0.0, 0.40, 0.00)        
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize  = 20
-		attachOnPart = true
-		attachOnEva = true
-	}
+		MODULE
+{
+        name = ModuleKISItem
+        shortcutKeyAction = drop
+        useName = use
+        usableFromEva = true
+        usableFromContainer = true
+        usableFromPod = true
+        usableFromEditor = true
+        stackable = false
+        volumeOverride = 2500
+        editorItemsCategory = false
+        moveSndPath = KIS/Sounds/itemMove
+        equipable = false
+        equipMode = model
+        equipSlot = <null>
+        equipSkill = <null>
+        equipRemoveHelmet = false
+        equipMeshName = helmet
+        equipBoneName = helmet01
+        equipPos = (0, 0, 0)
+        equipDir = (0, 0, 0)
+        carriable = true
+        allowAttachOnStatic = false
+}
 
 	MODULE
 	{

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_MobileBase.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_MobileBase.cfg
@@ -56,7 +56,7 @@ PART
 	MODULE
 	{
 		name = ModuleKISInventory
-		maxVolume = 50
+		maxVolume = 5000
 		externalAccess = true
 		internalAccess = false
 		slotsX = 10

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ModuleBase.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_ModuleBase.cfg
@@ -63,7 +63,7 @@ PART
 	MODULE
 	{
 		name = ModuleKISInventory
-		maxVolume = 50
+		maxVolume = 5000
 		externalAccess = true
 		internalAccess = false
 		slotsX = 10


### PR DESCRIPTION
Set MKS module base to 5000-  I came to this number by taking the standard KIS container, which holds 1000 and stacked 4 next to an MKS base module.  The MKS base module is a bit larger than for KIS containers so 5000 seemed fair.
Set Mk3 to 6500- MK3's are slightly larger so I gave them slightly more space.
changed inflatable Ag and Hab to KISItem and storage size to 2500 so 2
can be fit in a MKS base.  These two inflatables were KAS attachable before and can be KIS attached without modification.  Unfortunately letting KIS calculate the volume automatically caused them to be far too large to fit in any storage container.  I seem to recall being able to fit 2 into an MKS base before, so i set their KIS storage size to 2500 so you can fit 2 in an MKS base.