### PR TITLE
add USI_ModuleRecycleBin to OctoLander.cfg

### DIFF
--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/OctoLander.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/OctoLander.cfg
@@ -104,4 +104,9 @@ MODULE
   	 key = 1 100
  	}
 }
+MODULE
+	{
+		name = USI_ModuleRecycleBin
+	}
+
 }


### PR DESCRIPTION
added USI_modulerecycleBin to Octolander, so they tanks can receive recyclables from scrapping parts when they are setup to have such storage,  (previously they wernt. )