### PR TITLE
Added RemoteTech Support to MkVCommpack

### DIFF
--- a/GameData/UmbraSpaceIndustries/Kolonization/MKS_OKS_RT2.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/MKS_OKS_RT2.cfg
@@ -60,7 +60,7 @@
 		%MaxQ = 6000
 		%EnergyCost = 0.13
 		
-		%DeployFxModules = 0
+		%DeployFxModules = 1
 		
 		%TRANSMITTER 
 		{

--- a/GameData/UmbraSpaceIndustries/Kolonization/MKS_OKS_RT2.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/MKS_OKS_RT2.cfg
@@ -45,3 +45,30 @@
 		IsRTCommandStation = true
 	}
 }
+
+@PART[MKV_CommPak]:AFTER[KolonyTools]:NEEDS[RemoteTech]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	%MODULE[ModuleRTAntenna] 
+	{
+		%Mode0OmniRange = 0
+		%Mode1OmniRange = 2500000
+		%MaxQ = 6000
+		%EnergyCost = 0.13
+		
+		%DeployFxModules = 0
+		
+		%TRANSMITTER 
+		{
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}	


### PR DESCRIPTION
Added RemoteTech Support to MkVCommpack.  Gave it the same omni range as the extendable whip antenna you get early (2.5Mm)