### PR TITLE
Only add internal placeholder to vessels with actual crew capacity.

### DIFF
--- a/GameData/UmbraSpaceIndustries/Kolonization/MMIVA.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/MMIVA.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[#CrewCapacity[*],!INTERNAL[]]:FINAL
+@PART[*]:HAS[#CrewCapacity[>0],!INTERNAL[]]:FINAL
 {
   INTERNAL
 {


### PR DESCRIPTION
The placeholder internal has seats, so adding it to things such as probe cores can confuse some of the contracts, causing kerbals to be stuffed in places kerbals should not be stuffed. This should fix that.