### PR TITLE
Remove references to no longer existing parts

### DIFF
--- a/GameData/UmbraSpaceIndustries/Kolonization/CTT.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/CTT.cfg
@@ -3,10 +3,6 @@
     @TechRequired = shortTermHabitation
 }
 
-@PART[MKS_AgModule]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = longTermHabitation
-}
 @PART[MKS_Aeroponics]:NEEDS[CommunityTechTree]
 {
     @TechRequired = longTermHabitation

--- a/GameData/UmbraSpaceIndustries/Kolonization/MKS_DRE.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/MKS_DRE.cfg
@@ -1,9 +1,6 @@
 // Deadly Re-Entry support for MKS
 
 // MKS
-@PART[MKS_AgModule]:FOR[MKS]:NEEDS[DeadlyReentry] {
-    @maxTemp = 800
-}
 @PART[MKS_Antenna]:FOR[MKS]:NEEDS[DeadlyReentry] {
     @maxTemp = 1500
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/MKS_DRE.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/MKS_DRE.cfg
@@ -43,9 +43,6 @@
 @PART[MKS_Greenhouse]:FOR[MKS]:NEEDS[DeadlyReentry] {
     @maxTemp = 1450
 }
-@PART[MKS_HabDome]:FOR[MKS]:NEEDS[DeadlyReentry] {
-    @maxTemp = 800
-}
 @PART[MKS_Kerbitat]:FOR[MKS]:NEEDS[DeadlyReentry] {
     @maxTemp = 1450
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_Aeroponics.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_Aeroponics.cfg
@@ -225,7 +225,7 @@ PART
 		name = MKSModule
 		workSpace = 1
 		livingSpace = 0
-		efficiencyPart = MKS_AgModule,2,MKV_AgModule,2,USILS_Greenhouse_LG,4
+		efficiencyPart = MKV_AgModule,2,USILS_Greenhouse_LG,4
 	}
 	MODULE
 	{

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_Kerbitat.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_Kerbitat.cfg
@@ -133,7 +133,7 @@ PART
 		name = MKSModule
 		workSpace = 1
 		livingSpace = 0
-		efficiencyPart = MKV_HabModule,2,MKS_HabDome,2
+		efficiencyPart = MKV_HabModule,2
 	}
 	MODULE
 	{

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_AgModule.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_AgModule.cfg
@@ -201,4 +201,10 @@ PART
 	{
 		name = USI_ModuleFieldRepair
 	}
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		passableWhenSurfaceAttached = true
+	}
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_Airlock.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_Airlock.cfg
@@ -68,5 +68,10 @@ PART
         carriable = true
         allowAttachOnStatic = false
 	}
-
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		passableWhenSurfaceAttached = true
+	}
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_AuxCon.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_AuxCon.cfg
@@ -94,4 +94,10 @@ PART
 		name = ModuleCommand
 		minimumCrew = 1	
 	}
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		passableWhenSurfaceAttached = true
+	}
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_BallHub.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_BallHub.cfg
@@ -35,4 +35,9 @@ PART
 	maxTemp = 1700
 	bulkheadProfiles = size2
 
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_CommPak.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_CommPak.cfg
@@ -139,5 +139,11 @@ PART
 		amount = 500
 		maxAmount = 500
 		isTweakable = True
-	}		
+	}
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		passableWhenSurfaceAttached = true
+	}
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_HabModule.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_HabModule.cfg
@@ -159,5 +159,11 @@ PART
 	INTERNAL
 	{
 		name = crewCabinInternals
-	}		
+	}
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		passableWhenSurfaceAttached = true
+	}
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_ILM.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_ILM.cfg
@@ -107,4 +107,10 @@ PART
 	{
 		name = USI_ModuleRecycleBin
 	}
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		passableWhenSurfaceAttached = true
+	}
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_Lander.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_Lander.cfg
@@ -85,4 +85,11 @@ PART
 		closeSndPath = KIS/Sounds/containerClose
 		defaultMoveSndPath = KIS/Sounds/itemMove
 	}
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		impassablenodes = bottom
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_Pod.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_Pod.cfg
@@ -111,6 +111,10 @@ PART
 		workSpace = 1
 		livingSpace = 0
 		hasGenerators = false
-	}	
-	
+	}
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_Workshop.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_Workshop.cfg
@@ -223,4 +223,10 @@ PART
 		name = ExWorkshop
 		ProductivityFactor = 2
 	}
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		passableWhenSurfaceAttached = true
+	}
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/OctoLander.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/OctoLander.cfg
@@ -37,9 +37,6 @@ PART
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
-		passableWhenSurfaceAttached = true
-		impassablenodes = bottom
-		surfaceAttachmentsPassable = true
 	}
 	MODULE
 	{


### PR DESCRIPTION
Some old and no longer existing parts (MKS_AgModule and MKS_HabDome) are still referenced as efficiency parts and in CTT and DRE configs.
This Pull Request removes these references.

Also update CLP configs for MKV modules