### PR TITLE
Fix TAC-LS file for MKV: needed machinery must match available space

### DIFF
--- a/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
@@ -110,7 +110,7 @@
 		REQUIRED_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 2000
+			Ratio = 200
 		}
 	}  
 }
@@ -424,7 +424,7 @@
 		REQUIRED_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 2000
+			Ratio = 200
 		}
 	}
 }


### PR DESCRIPTION
MKV Greenhouse and Habitat required 2000 machinery for full capacity but only had space for 200. Solution: shrink required machinery to 200.