### PR TITLE
Fix another NaN bug in GetDistanceBetweenPoints

### DIFF
--- a/Source/KolonyTools/KolonyTools/OrbitalLogistics.cs
+++ b/Source/KolonyTools/KolonyTools/OrbitalLogistics.cs
@@ -162,8 +162,8 @@ namespace KolonyTools
             double dLat = (lat2 - lat1) / 180 * Math.PI;
             double dLong = (long2 - long1) / 180 * Math.PI;
 
-            double a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2)
-                        + Math.Cos(lat2 / 180 * Math.PI) * Math.Sin(dLong / 2) * Math.Sin(dLong / 2);
+            double a = Math.Max(0.0, Math.Min(1.0, Math.Sin(dLat / 2) * Math.Sin(dLat / 2)
+                        + Math.Cos(lat2 / 180 * Math.PI) * Math.Sin(dLong / 2) * Math.Sin(dLong / 2)));
             double c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
 
             //Calculate radius of planet


### PR DESCRIPTION
Due to numerical precision issues, `a` can wind up greater than 1, or possibly less than 0, which causes `NaN` on the next line due to taking the square root of a negative number. This change clamps `a` between `0.0` and `1.0` to prevent this from happening. This could be contributing to #262, #286, #584 and #585; this code should only be run for surface-surface and orbit-orbit transfers, but there's a bug in how the vessel situations are determined (see #605) that may cause it to be run in other conditions too.