### PR TITLE
Remove references to no longer existing parts

### DIFF
--- a/GameData/UmbraSpaceIndustries/Kolonization/CTT.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/CTT.cfg
@@ -3,10 +3,6 @@
     @TechRequired = shortTermHabitation
 }
 
-@PART[MKS_AgModule]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = longTermHabitation
-}
 @PART[MKS_Aeroponics]:NEEDS[CommunityTechTree]
 {
     @TechRequired = longTermHabitation

--- a/GameData/UmbraSpaceIndustries/Kolonization/MKS_DRE.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/MKS_DRE.cfg
@@ -1,9 +1,6 @@
 // Deadly Re-Entry support for MKS
 
 // MKS
-@PART[MKS_AgModule]:FOR[MKS]:NEEDS[DeadlyReentry] {
-    @maxTemp = 800
-}
 @PART[MKS_Antenna]:FOR[MKS]:NEEDS[DeadlyReentry] {
     @maxTemp = 1500
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/MKS_DRE.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/MKS_DRE.cfg
@@ -43,9 +43,6 @@
 @PART[MKS_Greenhouse]:FOR[MKS]:NEEDS[DeadlyReentry] {
     @maxTemp = 1450
 }
-@PART[MKS_HabDome]:FOR[MKS]:NEEDS[DeadlyReentry] {
-    @maxTemp = 800
-}
 @PART[MKS_Kerbitat]:FOR[MKS]:NEEDS[DeadlyReentry] {
     @maxTemp = 1450
 }

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_Aeroponics.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_Aeroponics.cfg
@@ -225,7 +225,7 @@ PART
 		name = MKSModule
 		workSpace = 1
 		livingSpace = 0
-		efficiencyPart = MKS_AgModule,2,MKV_AgModule,2,USILS_Greenhouse_LG,4
+		efficiencyPart = MKV_AgModule,2,USILS_Greenhouse_LG,4
 	}
 	MODULE
 	{

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_Kerbitat.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_Kerbitat.cfg
@@ -133,7 +133,7 @@ PART
 		name = MKSModule
 		workSpace = 1
 		livingSpace = 0
-		efficiencyPart = MKV_HabModule,2,MKS_HabDome,2
+		efficiencyPart = MKV_HabModule,2
 	}
 	MODULE
 	{


### PR DESCRIPTION
Some old and no longer existing parts (MKS_AgModule and MKS_HabDome) are still referenced as efficiency parts and in CTT and DRE configs.
This Pull Request removes these references.