### PR TITLE
Base resource overview

### DIFF
--- a/Source/KolonyTools/KolonyTools/StationManager.cs
+++ b/Source/KolonyTools/KolonyTools/StationManager.cs
@@ -256,7 +256,7 @@ namespace KolonyTools
                 {
                     getResourceFromList(resources, r.resourceName).change -= r.amount;
                 }
-                ResourceConverter ddd;
+
                 // Drills
                 foreach (Part drill in v.Parts.Where(p => p.Modules.Contains("ModuleResourceHarvester")))
                 {
@@ -290,13 +290,19 @@ namespace KolonyTools
                 getResourceFromList(resources, "Mulch").change += kerbals * 0.00005;
                 getResourceFromList(resources, "ElectricCharge").change -= kerbals * 0.01;
             }
-
-            foreach (var r in resources)
+            resources.Sort(new LogisticsResourceComparer());
+            foreach (LogisticsResource r in resources)
             {
                 GUILayout.Label(r.resourceName + ": " + numberToOut(r.amount, -1, false) + "/" + Math.Round(r.maxAmount,5) + " (" + numberToOut(r.change, r.change > 0 ? r.maxAmount - r.amount : r.amount) + ")");
             }
         }
-
+        private class LogisticsResourceComparer : IComparer<LogisticsResource>
+        {
+            public int Compare(LogisticsResource a, LogisticsResource b)
+            {
+                return a.resourceName.CompareTo(b.resourceName);
+            }
+        }
         private LogisticsResource getResourceFromList(List<LogisticsResource> resources, string resourceName)
         {
             LogisticsResource nR = resources.Find(x => x.resourceName == resourceName);


### PR DESCRIPTION
This patch implements a base overview of all resources into the UKS-Station-Manager.

It uses the same functionality as the other Station-Manager-Tabs (Production, Consumption, Balance & Resources) meaning that the displayed numbers are not quite correct (this is already reported as #623).
Currently I can not provide a reasonable workaround for this issue, since it requires more knowledge about Stock-Regolith than I have.
So I will leave the implementation for the moment as it is:

![screenshot18](https://cloud.githubusercontent.com/assets/5959600/9705158/408da270-54bb-11e5-8bb7-4b2e340d5fce.jpg)

A small note about consumption rates of Life-Support-Systems:
USI-LS is supported
TAC-LS and Snacks are not supported