### PR TITLE
Fix small issues with rover logistics.

### DIFF
--- a/Source/KolonyTools/KolonyTools/MKSModule.cs
+++ b/Source/KolonyTools/KolonyTools/MKSModule.cs
@@ -463,7 +463,7 @@ namespace KolonyTools
                 if (fillPercent < 0.5d) //We will not attempt a fillup until we're at less than half capacity
                 {
                     //Keep changes small - 10% per tick.  So we should hover between 50% and 60%
-                    var deficit = Math.Floor(maxAmount * .1d);
+                    var deficit = maxAmount * .1d;
                     double receipt = FetchResources(deficit, pRes, fillPercent, maxAmount);
                     //Put these in our vessel
                     StoreResources(receipt, pRes);

--- a/Source/KolonyTools/KolonyTools/MKSModule.cs
+++ b/Source/KolonyTools/KolonyTools/MKSModule.cs
@@ -622,7 +622,7 @@ namespace KolonyTools
                 maxAmount += rr.maxAmount;
                 curAmount += rr.amount;
             }
-            double fillPercent = curAmount/maxAmount;
+            double fillPercent = maxAmount < ResourceUtilities.FLOAT_TOLERANCE ? 0 : curAmount / maxAmount;
             if (fillPercent > targetPercent)
             {
                 //If we're in better shape, they can take some of our stuff.


### PR DESCRIPTION
Rover Logistics now handles vessels with less than 10 units of a resource correctly. (don't round deficit down to next integer)
Avoid a division by 0.