### PR TITLE
Minor fix to the description of MK3 refinery

### DIFF
--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MK3_Refinery.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MK3_Refinery.cfg
@@ -21,7 +21,7 @@ PART
 	subcategory = -1
 	title = UKS Mobile Refinery
 	manufacturer = USI - Kolonization Division
-	description = A refinery for taking in raw resources to refine them into the metal, polymers and chemicals used for repairs and more advanced parts.  Requires at least one inflatable workshop, sifter, or smelter (for MKS) or inflatable workspace (for OKS) to operate.
+	description = A refinery for taking in raw resources to refine them into the metal, polymers and chemicals used for repairs and more advanced parts.  Requires at least one sifter, smelter (for MKS), or inflatable workspace (for OKS) to operate.
 	attachRules =1,0,1,1,0
 	mass = 2.50
 	dragModelType = default


### PR DESCRIPTION
The inflatable workshop is not an efficiency part for the MK3 refinery. I think the description is still a bit inaccurate because additional MKV parts are not really required.