### PR TITLE
Allow EPL workshops to drain RocketParts through logistics

### DIFF
--- a/Source/KolonyTools/KolonyTools/MKSModule.cs
+++ b/Source/KolonyTools/KolonyTools/MKSModule.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.Eventing.Reader;
 using System.Linq;
 using USITools;
 
@@ -414,6 +412,14 @@ namespace KolonyTools
                                    new ResourceRatio { ResourceName = "Oxygen" }, 
                                    new ResourceRatio { ResourceName = "ElectricCharge" }
                                });
+            }
+
+            // Special for ExtraPlanetary LaunchPads
+            if(part.Modules.Contains("ExWorkshop"))
+            {
+                CheckLogistics(new List<ResourceRatio> {
+                    new ResourceRatio { ResourceName = "RocketParts" }
+                });
             }
         }
 


### PR DESCRIPTION
This permits dedicating a building to extraction, refinery, and rocket parts fabrication, separated from the building having the pioneer/survey module.