### PR TITLE
Changing from DepletedUranium to DepletedFuel

### DIFF
--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MK3_FuelRefinery.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MK3_FuelRefinery.cfg
@@ -266,7 +266,7 @@ PART
 		
 		INPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.00085
 			FlowMode = STAGE_PRIORITY_FLOW
 		}
@@ -319,7 +319,7 @@ PART
 	
 	RESOURCE
 	{
-		name = DepletedUranium
+		name = DepletedFuel
 		amount = 0
 		maxAmount = 1000
 		isTweakable = True

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_PDU.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKS_PDU.cfg
@@ -111,7 +111,7 @@ PART
 	
 	RESOURCE
 	{
-		name = DepletedUranium
+		name = DepletedFuel
 		amount = 0
 		maxAmount = 500
 		isTweakable = True
@@ -226,7 +226,7 @@ PART
 		
 		INPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.00085
 			FlowMode = STAGE_PRIORITY_FLOW
 		}

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_SupPak.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/MKV_SupPak.cfg
@@ -77,7 +77,7 @@ PART
 	MODULE
 	{
 		name = FSfuelSwitch
-		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;RocketParts;Metals;EnrichedUranium,DepletedUranium;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer
+		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;RocketParts;Metals;EnrichedUranium,DepletedFuel;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer
 		resourceAmounts = 1250;1250;1250;1250;1250;625,625;250;1250;625,625;1250;1250;250;1250;1250;1250;1250
 		initialResourceAmounts = 0;0;0;0;0;0,0;0;0;0,0;0;0;0;0;0;0;0
 		tankCost = 3500;2500;2000;2500;2000;178000;2500;19000;55000;11000;19500;500;25000;12500;50000;7000

--- a/GameData/UmbraSpaceIndustries/Kolonization/Parts/OKS_PDU.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/Parts/OKS_PDU.cfg
@@ -64,7 +64,7 @@ PART
       }
       OUTPUT_RESOURCE
       {
-          ResourceName = DepletedUranium
+          ResourceName = DepletedFuel
           Ratio = 0.0000050
           DumpExcess = True
       }
@@ -90,7 +90,7 @@ isTweakable = True
 }
 RESOURCE
 {
-name = DepletedUranium
+name = DepletedFuel
 amount = 0
 maxAmount = 250
 isTweakable = True

--- a/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_01.cfg
+++ b/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_01.cfg
@@ -65,7 +65,7 @@ bulkheadProfiles = size1,srf
 	MODULE
 	{
 		name = FSfuelSwitch
-		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;RocketParts;Metals;EnrichedUranium,DepletedUranium;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer
+		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;RocketParts;Metals;EnrichedUranium,DepletedFuel;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer
 		resourceAmounts = 2500;2500;2500;2500;2500;1250,1250;500;2500;1250,1250;2500;2500;500;2500;2500;2500;2500
 		initialResourceAmounts = 0;0;0;0;0;0,0;0;0;0,0;0;0;0;0;0;0;0
 		tankCost = 7000;5000;4000;5000;4000;377000;5000;38000;1083000;22000;39000;600;50000;25000;100000;14000

--- a/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_02.cfg
+++ b/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_02.cfg
@@ -65,7 +65,7 @@ bulkheadProfiles = size2,srf
 	MODULE
 	{
 		name = FSfuelSwitch
-		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;RocketParts;Metals;EnrichedUranium,DepletedUranium;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer
+		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;RocketParts;Metals;EnrichedUranium,DepletedFuel;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer
 		resourceAmounts = 20000;20000;20000;20000;20000;10000,10000;4000;20000;10000,10000;20000;20000;4000;20000;20000;20000;20000
 		initialResourceAmounts = 0;0;0;0;0;0,0;0;0;0,0;0;0;0;0;0;0;0
 		tankCost = 42000;22000;14000;24000;14000;3008000;28000;292000;8657000;167000;307000;2000;325000;160000;650000;106000

--- a/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_03.cfg
+++ b/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_03.cfg
@@ -65,7 +65,7 @@ bulkheadProfiles = size3,srf
 	MODULE
 	{
 		name = FSfuelSwitch
-		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;RocketParts;Metals;EnrichedUranium,DepletedUranium;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer
+		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;RocketParts;Metals;EnrichedUranium,DepletedFuel;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer
 		resourceAmounts = 65000;65000;65000;65000;65000;32500,32500;13000;65000;32500,32500;65000;65000;13000;65000;65000;65000;65000
 		initialResourceAmounts = 0;0;0;0;0;0,0;0;0;0,0;0;0;0;0;0;0;0
 		tankCost = 136000;67000;42000;74000;43000;9772000;87000;948000;28134000;542000;997000;5000;1042000;460000;2110000;345000

--- a/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_04.cfg
+++ b/GameData/UmbraSpaceIndustries/Kontainers/Kontainer_04.cfg
@@ -65,7 +65,7 @@ bulkheadProfiles = size4,srf
 	MODULE
 	{
 		name = FSfuelSwitch
-		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;RocketParts;Metals;EnrichedUranium,DepletedUranium;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer
+		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;RocketParts;Metals;EnrichedUranium,DepletedFuel;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer
 		resourceAmounts = 160000;160000;160000;160000;160000;80000,80000;32000;160000;80000,80000;160000;160000;32000;160000;160000;160000;160000
 		initialResourceAmounts = 0;0;0;0;0;0,0;0;0;0,0;0;0;0;0;0;0;0
 		tankCost = 336000;152000;120000;184000;103000;24052000;105000;2328000;61314000;1432000;2457000;55000;2582000;1170000;5170000;855000

--- a/GameData/UmbraSpaceIndustries/ReactorPack/Parts/Nuke_125.cfg
+++ b/GameData/UmbraSpaceIndustries/ReactorPack/Parts/Nuke_125.cfg
@@ -55,7 +55,7 @@ PART
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.00000026
 			DumpExcess = true		
 		}
@@ -81,7 +81,7 @@ PART
 	}
 	RESOURCE
 	{
-	 name = DepletedUranium
+	 name = DepletedFuel
 	 amount = 0
 	 maxAmount = 11
 	}

--- a/GameData/UmbraSpaceIndustries/ReactorPack/Parts/Nuke_250.cfg
+++ b/GameData/UmbraSpaceIndustries/ReactorPack/Parts/Nuke_250.cfg
@@ -55,7 +55,7 @@ PART
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.000002
 			DumpExcess = true		
 		}
@@ -81,7 +81,7 @@ PART
 	}
 	RESOURCE
 	{
-	 name = DepletedUranium
+	 name = DepletedFuel
 	 amount = 0
 	 maxAmount = 77
 	}

--- a/GameData/UmbraSpaceIndustries/ReactorPack/Parts/Nuke_375.cfg
+++ b/GameData/UmbraSpaceIndustries/ReactorPack/Parts/Nuke_375.cfg
@@ -55,7 +55,7 @@ PART
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.0000056
 			DumpExcess = true		
 		}
@@ -81,7 +81,7 @@ PART
 	}
 	RESOURCE
 	{
-	 name = DepletedUranium
+	 name = DepletedFuel
 	 amount = 0
 	 maxAmount = 225
 	}

--- a/GameData/UmbraSpaceIndustries/ReactorPack/Parts/Nuke_625.cfg
+++ b/GameData/UmbraSpaceIndustries/ReactorPack/Parts/Nuke_625.cfg
@@ -55,7 +55,7 @@ PART
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = DepletedUranium
+			ResourceName = DepletedFuel
 			Ratio = 0.00000004
 			DumpExcess = true		
 		}
@@ -81,7 +81,7 @@ PART
 	}
 	RESOURCE
 	{
-	 name = DepletedUranium
+	 name = DepletedFuel
 	 amount = 0
 	 maxAmount = 1
 	}

--- a/Source/KolonyTools/KolonyTools/USI_ModuleFieldRepair.cs
+++ b/Source/KolonyTools/KolonyTools/USI_ModuleFieldRepair.cs
@@ -28,7 +28,7 @@ namespace KolonyTools
             GrabResources("Machinery");
             GrabResources("EnrichedUranium");
             PushResources("Recyclables");
-            PushResources("DepletedUranium");
+            PushResources("DepletedFuel");
         }
 
         public override void OnStart(StartState state)


### PR DESCRIPTION
I went through and changed every instance of DepletedUranium to DepletedFuel, **EXCEPT** the two legacy PDU parts (OKS and MKS). I could change those also. I went through the reactors, the Kontainers, and the Kolonization parts.

This could create the issue of people with existing bases losing their DepletedUranium, but they won't get any depletedfuel in exchange, so it would be worth noting that they should reprocess it or lose it, before updating.

Also, I note that in the CRP definitions, depletedUranium was set to tweakable = true while DepletedFuel has tweakable = false. Mostly that'll just affect people testing on the pad.