### PR TITLE
Fix efficiency parts not being taken into account when they are the root part of a vessel

### DIFF
--- a/Source/KolonyTools/KolonyTools/MKSModule.cs
+++ b/Source/KolonyTools/KolonyTools/MKSModule.cs
@@ -138,7 +138,9 @@ namespace KolonyTools
                         var effPartList = new List<Part>();
                         foreach (var v in vList)
                         {
-                            effPartList.AddRange(v.Parts.Where(p => p.name == vep.Name));
+                            var nameWhenRootPart = vep.Name + " (" + v.GetName() + ")";
+                            var pList = v.Parts.Where(p => p.name == vep.Name || p.name == nameWhenRootPart);
+                            effPartList.AddRange(pList);
                         }
 
                         foreach (var ep in effPartList)


### PR DESCRIPTION
I don't know if this solution is more or less robust than checking a prefix.

Another possibility, if abusing modules is not advised against, could be to add a module to efficiency parts, explicitly saying that they are boosting such and such converters. This way, the part search would be more robust, and the efficiency boost could also appear in the part description, for in-game documentation.
