### PR TITLE
Add CLS to Hub

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/Parts/OKS_Hub6Way.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/Parts/OKS_Hub6Way.cfg
@@ -40,4 +40,9 @@ PART
 	breakingTorque = 280
 	maxTemp = 1700
 	bulkheadProfiles = size2
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }


### PR DESCRIPTION
It seems logical that the hubs should be CLS passable, but I'm not sure of your intent with these parts. Both OKS hubs lack the relevant module, but I figured it polite to only create one pull.