### PR TITLE
Fix OKS Kerbitat Life Support Recycler Water Consumption

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Kerbitat.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Kerbitat.cfg
@@ -119,7 +119,7 @@ PART
 		INPUT_RESOURCE
 		{
 			ResourceName = Water
-			Ratio = 20
+			Ratio = 0.005
 		}		
 		INPUT_RESOURCE
 		{


### PR DESCRIPTION
Reduce the water consumption of ModuleLifeSupportRecycler in the OKS
(Orbital) Kerbitat down to the level of the MKS (ground) Kerbitat