### PR TITLE
Removed duplicate of Fertilizer module

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MK3_Sifter.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MK3_Sifter.cfg
@@ -248,49 +248,6 @@ PART
 		name = ExWorkshop
 		ProductivityFactor  = 5
 	}
-	
-	ResourceName	MODULE
-	{
-		name = ModuleResourceConverter
-		ConverterName = Fertilizer
-		StartActionName = Start Fertilizer
-		StopActionName = Stop Fertilizer
-
-		INPUT_RESOURCE
-		{
-			ResourceName = Gypsum
-			Ratio = 2.5
-		}
-		
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 18
-		}
-		
-		INPUT_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 0.000001
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Fertilizer
-			Ratio = 0.25
-			DumpExcess = True
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Recyclables
-			Ratio = 0.000001
-			DumpExcess = true
-		}
-		REQUIRED_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 2000
-		}
-	}
 
 	RESOURCE
 	{


### PR DESCRIPTION
UKS Industrial Regolith Sifter - config had two identical Fertilizer ResourceConverter modules.