### PR TITLE
texture replacement string is invalid

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Workshop.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Workshop.cfg
@@ -6,8 +6,8 @@ PART
 	MODEL
 	{
 		model = UmbraSpaceIndustries/UKS/Assets/StationModule
-		texture = OKSDecal00 , 
-		texture = OKSDecal00_GLOW , 
+		texture = OKSDecal00 , UmbraSpaceIndustries/UKS/Assets/OKSDecal08
+		texture = OKSDecal00_GLOW , UmbraSpaceIndustries/UKS/Assets/OKSDecal08_GLOW
 	}
 	rescaleFactor = 1
 	scale = 1


### PR DESCRIPTION
PartLoader: Compiling Part 'UmbraSpaceIndustries/UKS/Parts/OKS_Workshop/OKS_Workshop'
PartCompiler: Cannot replace texture as texture replacement string is invalid. Syntax is 'origTextureName newTextureURL'