### PR TITLE
Various description edits, plus suggestions for the CRP resource definitions file

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -105,7 +105,7 @@ RESOURCE_DEFINITION
 {
 	name = Food
 	density = 0.00028102905982906
-	hsp = 600 // specific heat capacity (kJ/tonne-K as units) // FIXME total guess
+	hsp = 1657 // specific heat capacity (kJ/tonne-K as units) @ 298 K
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
@@ -386,7 +386,7 @@ RESOURCE_DEFINITION
 {
 	name = Waste
 	density = 0.00075
-	hsp = 600 // specific heat capacity (kJ/tonne-K as units) // FIXME total guess
+	hsp = 2710 // specific heat capacity (kJ/tonne-K as units) @ 293 K
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
@@ -398,7 +398,7 @@ RESOURCE_DEFINITION
 {
 	name = WasteWater
 	density = 0.001005
-	hsp = 4183 // specific heat capacity (kJ/tonne-K as units) (FIXME same as water)
+	hsp = 4183 // specific heat capacity (kJ/tonne-K as units)
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/Parts/LightGlobe.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/Parts/LightGlobe.cfg
@@ -18,7 +18,7 @@ PART
 	subcategory = 0
 	title = 'Sunflower' Portable Light Kit
 	manufacturer = Umbra Space Industries
-	description = A fully deployable, portable light kit.  Includes solar panels, and power coupling for situations where the built in solar panels are inadequate.
+	description = A fully deployable, portable light kit.  Includes solar panels, and power coupling for situations where the built-in solar panels are inadequate.
 	attachRules = 1,1,0,0,0
 	mass = 0.01
 	dragModelType = default

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/Parts/PowerAntenna.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/Parts/PowerAntenna.cfg
@@ -30,7 +30,7 @@ category = Utility
 subcategory = 0
 title = Microwave Power Tranceiver
 manufacturer = Umbra Space Industries
-description = Allows for the transfer of power via microwave transmission
+description = Allows for the transfer of power via microwave transmission.  Not intended for remotely reheating snacks.
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,0

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MK3_Fabricator.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MK3_Fabricator.cfg
@@ -21,7 +21,7 @@ PART
 	subcategory = 0
 	title = UKS Fabrication Module
 	manufacturer = USI - Kolonization Division
-	description = A small mobile factory that can fabricate the specialized parts required to make a colony more self sufficient.  It also includes a recycling plant where recycleables can be broken down into their component resources.  Requires at least one inflatable workshop (for MKS) or inflatable workspace (for OKS) to operate.
+	description = A small mobile factory that can fabricate the specialized parts required to make a colony more self-sufficient.  It also includes a recycling plant where recycleables can be broken down into their component resources.  Requires at least one inflatable workshop (for MKS) or inflatable workspace (for OKS) to operate.
 	attachRules =1,0,1,1,0
 	mass = 2.50
 	dragModelType = default

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_Drill_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_Drill_01.cfg
@@ -18,7 +18,7 @@ PART
 	subcategory = 0
 	title = MEU-500 Drill [MetallicOre/Substrate/Uraninite]
 	manufacturer = USI - Kolonization Division
-	description = The MEU-500 pulse drill can be used to excavate Metallic Ore, Uraninite, and substrate from planetary surfaces.
+	description = The MEU-500 pulse drill can be used to excavate metallic ore, uraninite, and substrate from planetary surfaces.
 
 	TechRequired = advScienceTech
 	entryCost = 50

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_ExpandoTube2.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_ExpandoTube2.cfg
@@ -24,7 +24,7 @@ PART
 	subcategory = 0
 	title = UKS Kerbitrail(tm) ExpandoTube Mini
 	manufacturer = USI - Kolonization Division
-	description = A fully inflatable tube used to interconnect base components.  Do not, under any circumstances back into an armed ExpandoTube (Seriously, this is a bug with KSP and horrible things happen).  Also do not use to make balloon animals.  Expands to 2 Meters.
+	description = A fully inflatable tube used to interconnect base components.  Do not, under any circumstances, back into an armed ExpandoTube (Seriously, this is a bug with KSP and horrible things happen).  Also do not use to make balloon animals.  Expands to 2 Meters.
 
 	attachRules = 1,1,0,0,0
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_ExpandoTube4.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_ExpandoTube4.cfg
@@ -24,7 +24,7 @@ PART
 	subcategory = 0
 	title = UKS Kerbitrail(tm) ExpandoTube
 	manufacturer = USI - Kolonization Division
-	description = A fully inflatable tube used to interconnect base components.  Do not, under any circumstances back into an armed ExpandoTube (Seriously, this is a bug with KSP and horrible things happen).  Also do not use to make balloon animals.  Expands to 4 meters.
+	description = A fully inflatable tube used to interconnect base components.  Do not, under any circumstances, back into an armed ExpandoTube (Seriously, this is a bug with KSP and horrible things happen).  Also do not use to make balloon animals.  Expands to 4 meters.
 
 	attachRules = 1,1,0,0,0
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_ExpandoTube8.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_ExpandoTube8.cfg
@@ -24,7 +24,7 @@ PART
 	subcategory = 0
 	title = UKS Kerbitrail(tm) ExpandoTube XL
 	manufacturer = USI - Kolonization Division
-	description = A fully inflatable tube used to interconnect base components.  Do not, under any circumstances back into an armed ExpandoTube (Seriously, this is a bug with KSP and horrible things happen).  Also do not use to make balloon animals.  Expands to 8 meters.
+	description = A fully inflatable tube used to interconnect base components.  Do not, under any circumstances, back into an armed ExpandoTube (Seriously, this is a bug with KSP and horrible things happen).  Also do not use to make balloon animals.  Expands to 8 meters.
 
 	attachRules = 1,1,0,0,0
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_FlexOTube.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_FlexOTube.cfg
@@ -18,7 +18,7 @@ PART
 	subcategory = 0
 	title = UKS Kerbitrail(tm) FlexOTube
 	manufacturer = USI - Kolonization Division
-	description = Expandable, Bendable, attachable tubes up to 50m long.  Requires KAS.
+	description = Expandable, bendable, attachable tubes up to 50m long.  Requires KAS.
 	attachRules = 1,1,0,0,0
 
 	TechRequired = Unresearcheable

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKV_Sifter.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKV_Sifter.cfg
@@ -22,7 +22,7 @@ PART
 	subcategory = 0
 	title = MK-V Regolith Sifter
 	manufacturer = USI - Kolonization Division
-	description = Shovel in rock, crank the handle, filter out useful stuff.  Useful during initial exploration due to it's light weight.  Limited to deposits of 2.5% or greater.
+	description = Shovel in rock, crank the handle, filter out useful stuff.  Useful during initial exploration due to its light weight.  Limited to deposits of 2.5% or greater.
 
 	attachRules = 1,0,0,0,0
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKV_Workshop.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKV_Workshop.cfg
@@ -22,7 +22,7 @@ PART
 	subcategory = 0
 	title = MK-V Inflatable Workshop
 	manufacturer = USI - Kolonization Division
-	description = An inflatable workshop suitable for small-scale fabrication.  Can also help increase efficiency when combined with a larger MKS Fabrication module.  Note that due to the low-scale nature of this module, a 50% ratio of Specialized Parts are required to create finished goods.
+	description = An inflatable workshop suitable for small-scale fabrication.  Can also help increase efficiency when combined with a larger MKS Fabrication module.  Note that due to the low-scale nature of this module, a 50% ratio of Specialized Parts is required to create finished goods.
 
 	attachRules = 1,0,0,0,0
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_AgModule.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_AgModule.cfg
@@ -17,7 +17,7 @@ PART
 	subcategory = 0
 	title = OKS Agricultural Module
 	manufacturer = USI - Kolonization Division
-	description = An inflatable greenhouse for growing fresh food by using recycled mulch and fertilizer to grow plants.  Can work on it's own as a natural compost-driven greenhouse, or in combination with an OKS Agroponics Module cultivator for even more food production.  Also includes a basic life support recycler.
+	description = An inflatable greenhouse for growing fresh food by using recycled mulch and fertilizer to grow plants.  Can work on its own as a natural compost-driven greenhouse, or in combination with an OKS Agroponics Module cultivator for even more food production.  Also includes a basic life support recycler.
 	attachRules = 1,0,1,1,0
 	mass = 1.5
 	dragModelType = default

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Hub.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Hub.cfg
@@ -26,7 +26,7 @@ PART
 	subcategory = 0
 	title = OKS Hub Connector
 	manufacturer = USI - Kolonization Division
-	description = Want to go left or right as well as up and down?  Then use this handy station hub to add four way intersections to your station configuration!  Docking ports not included.
+	description = Want to go left or right as well as up and down?  Then use this handy station hub to add four-way intersections to your station configuration!  Docking ports not included.
 	attachRules = 1,0,1,0,0
 	mass = 1.25
 	dragModelType = default

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Hub6Way.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Hub6Way.cfg
@@ -28,7 +28,7 @@ PART
 	subcategory = 0
 	title = OKS Hub Connector 6 Way (Large)
 	manufacturer = USI - Kolonization Division
-	description = Want to go left or right, up and down or even front and back?  Then use this handy station hub to add six way intersections to your station configuration!  Docking ports not included.
+	description = Want to go left or right, up and down, or even front and back?  Then use this handy station hub to add six-way intersections to your station configuration!  Docking ports not included.
 	attachRules = 1,0,1,0,0
 	mass = 1.25
 	dragModelType = default

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_LgHub.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_LgHub.cfg
@@ -26,7 +26,7 @@ PART
 	subcategory = 0
 	title = OKS Hub Connector (Large)
 	manufacturer = USI - Kolonization Division
-	description = Want to go left or right as well as up and down?  Then use this handy station hub to add four way intersections to your station configuration!  Docking ports not included.
+	description = Want to go left or right as well as up and down?  Then use this handy station hub to add four-way intersections to your station configuration!  Docking ports not included.
 	attachRules = 1,0,1,0,0
 	mass = 1.25
 	dragModelType = default

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Workshop.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Workshop.cfg
@@ -21,7 +21,7 @@ PART
 	subcategory = 0
 	title = UKS Orbital Workshop
 	manufacturer = USI - Kolonization Division
-	description = An inflatable workshop suitable for small-scale fabrication.  Can also help increase efficiency when combined with a larger MKS Fabrication module.  Note that due to the low-scale nature of this module, a 50% ratio of Specialized Parts are required to create finished goods.
+	description = An inflatable workshop suitable for small-scale fabrication.  Can also help increase efficiency when combined with a larger MKS Fabrication module.  Note that due to the low-scale nature of this module, a 50% ratio of Specialized Parts is required to create finished goods.
 	attachRules =1,0,1,1,0
 	mass = 3
 	dragModelType = default


### PR DESCRIPTION
The description edits are all tiny typo fixes, plus one 'Do not remotely heat snacks' warning added to the microwave antenna for laughs.

The CRP stuff is an answer to the TAC-LS specific heat capacity bits with //FIXME: total guess tags, based on a quick-pass research effort.  Rationale and references are included.