### PR TITLE
Update CTT.cfg - Issue #865

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/CTT.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/CTT.cfg
@@ -20,7 +20,11 @@
 {
     @TechRequired = offworldManufacturing
 }
-@PART[MK3_Sifter]:NEEDS[CommunityTechTree]
+@PART[MK3_FuelRefinery]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = offworldManufacturing
+}
+@PART[MK3_IndustrialSifter]:NEEDS[CommunityTechTree]
 {
     @TechRequired = offworldManufacturing
 }


### PR DESCRIPTION
Fixed the CTT references for the Mk3_IndustrialSifter and the Mk3_FuelRefinery. Submitted to close issue #865