### PR TITLE
Inflatable storage: use deflated volume for KIS

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/UKS-KIS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/UKS-KIS.cfg
@@ -1,0 +1,38 @@
+// KIS uses the prefab (icon) to determine size.  All the inflatable prefabs are inflated.
+// The prefab being inflated is good, because it helps to place the part via KIS.
+//
+// However for transport/storage, the inflatable should be assumed to be uninflated.
+
+// OKS Inflatable Storage Module (ISM)
+// For comparison, X200-32 and X200-16 together are 38412.09
+@PART[OKS_Storage_ILM]:BEFORE[KIS]
+{
+	MODULE
+	{
+		name=ModuleKISItem
+		volumeOverride=38400
+	}
+}
+
+// UKS Inflatable Logistics Module (ILM)
+// For comparison, UKS Workspace Module is 10853.80
+@PART[MKS_Storage_ILM]:BEFORE[KIS]
+{
+	MODULE
+	{
+		name=ModuleKISItem
+		volumeOverride=10800
+	}
+}
+
+
+// MK-V Inflatable Storage Module
+// For comparison, MK-V Scout 200 Power Pack is 1000
+@PART[MKV_ILM]:BEFORE[KIS]
+{
+	MODULE
+	{
+		name=ModuleKISItem
+		volumeOverride=1000
+	}
+}


### PR DESCRIPTION
Set KIS volume for the 3 inflatable storage containers to uninflated size.  This will allow users to ship up uninflated storage containers in KIS containers.

However, this patch also allows players to put an inflated ILM full of resources into a tiny KIS container, which is fairly cheaty.  For that reason you may not want to merge it.

![volume](https://cloud.githubusercontent.com/assets/5103358/16540065/3f8b954a-405f-11e6-9ad2-5f8cf1cabe21.png)

![volume2](https://cloud.githubusercontent.com/assets/5103358/16540089/f091b52c-405f-11e6-8205-5604f2d16569.png)
