### PR TITLE
Fix for Kerbitat water purifier dumping water.

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_Kerbitat.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/MKS_Kerbitat.cfg
@@ -143,8 +143,13 @@ PART
 		}
 		INPUT_RESOURCE
 		{
-			ResourceName = Water
+			ResourceName = WasteWater
 			Ratio = 0.005
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.004
 		}		
 	}
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Kerbitat.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/Parts/OKS_Kerbitat.cfg
@@ -114,8 +114,13 @@ PART
 		}
 		INPUT_RESOURCE
 		{
-			ResourceName = Water
+			ResourceName = WasteWater
 			Ratio = 0.005
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.004
 		}		
 	}
 


### PR DESCRIPTION
I noticed that when using MKS with TLS that the Water Purifier just dumps water. I noticed that it had Water as the only input and no output, so I added WasteWater and swapped them around. I wasn't sure what efficiency to aim for though, so the value for Water may need to be edited.

It seems to work well in-game, yay for first pull request.
