### PR TITLE
Added Salamander & Scout Lander Mk2 to Stock Tech Tree

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/CTT.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/CTT.cfg
@@ -159,4 +159,11 @@
 {
     @TechRequired = shortTermHabitation
 }
-
+@PART[SalamanderPod]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = simpleCommandModules
+}
+@PART[ScoutLanderMk2]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = simpleCommandModules
+}

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Salamander.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Salamander.cfg
@@ -3,7 +3,7 @@ PART
 	name = SalamanderPod
 	module = Part
 	author = Roverdude
-	
+
 	MODEL
 	{
 		model = UmbraSpaceIndustries/MKS/Assets/Salamander
@@ -12,8 +12,8 @@ PART
 	node_stack_fairing = 0.0, 1.05, 0.0, 0.0, 1.0, 0.0, 1
 	node_stack_top = 0.0, 0.91, 0.0, 0.0, 1.0, 0.0, 1
 	node_stack_bottom = 0.0, -0, 0.0, 0.0, -1.0, 0.0, 1
-	
-	TechRequired = simpleCommandModules
+
+	TechRequired = advFlightControl
 	entryCost = 8100
 	cost = 200
 	category = Pods
@@ -40,7 +40,7 @@ PART
 	{
 		name = SalamanderInternal
 	}
-	
+
 	MODULE
 	{
 		name = ModuleJettison
@@ -50,9 +50,9 @@ PART
 		jettisonedObjectMass = 0.5
 		jettisonForce = 15
 		jettisonDirection = 0 0 1
-	}	
+	}
 
-	
+
 	MODULE
 	{
 		name = ModuleCommand
@@ -68,7 +68,7 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 2
-	}	
+	}
 	MODULE
 	{
 		name = ModuleReactionWheel
@@ -110,13 +110,13 @@ PART
 	{
 		name = MKSModule
 	}
-	
+
 	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
 	}
-	
+
 	MODULE
 	{
 		name = ModuleLifeSupportRecycler
@@ -135,5 +135,5 @@ PART
 	MODULE
 	{
 		name = ModulePowerCoupler
-	}	
+	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/ScoutLanderMk2.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/ScoutLanderMk2.cfg
@@ -3,22 +3,22 @@
 	name = ScoutLanderMk2
 	module = Part
 	author = Roverdude
-	
+
 	MODEL
 	{
-		model = UmbraSpaceIndustries/MKS/Assets/ScoutLanderMk2	
+		model = UmbraSpaceIndustries/MKS/Assets/ScoutLanderMk2
 	}
 	rescaleFactor = 1
-	
+
 	node_stack_pod01 = .85,-0.20763,0,  1,0,0,2
 	node_stack_pod02 = -.85,-0.20763,0, -1,0,0,2
 	node_stack_pod03 = 0,-0.20763,.85,  0,0,1,2
 	node_stack_pod04 = 0,-0.20763,-.85, 0,0,-1,2
-	
+
 	node_stack_top = 0.0, 0.721, 0.0, 0.0, 1.0, 0.0, 1
 	node_stack_bottom = 0.0, -0.721, 0.0, 0.0, -1.0, 0.0, 1
-	
-	TechRequired = simpleCommandModules
+
+	TechRequired = advFlightControl
 	entryCost = 8100
 	cost = 200
 	category = Utility
@@ -38,7 +38,7 @@
 	breakingTorque = 2000
 	maxTemp = 1200 // = 2900
 	bulkheadProfiles = srf
-	
+
 	MODULE
 	{
 		name = ModuleAnimateGeneric
@@ -48,8 +48,8 @@
 		endEventGUIName = Retract Stabilizers
 		actionGUIName = Toggle Stabilizers
 		allowAnimationWhileShielded = False
-	}	
-	
+	}
+
 	MODULE
 	{
 		name = ModuleKISInventory
@@ -71,7 +71,7 @@
 		passable = true
 		impassablenodes = bottom
 		surfaceAttachmentsPassable = true
-	}	
+	}
 	RESOURCE
 	{
 		name=ElectricCharge
@@ -82,5 +82,5 @@
 	MODULE
 	{
 		name = ModuleWeightDistributor
-	}	
+	}
 }


### PR DESCRIPTION
The new Salamander and Scout Lander Mk2 were both defaulting to a Community Tech Tree-only node (simpleCommandModules) and wouldn't show up in career. @slightlylyons and I guessed that the Adv. Flight Control node—where the Mk1 Lander Can unlocks—seemed like a decent fit for balance. 

Does that seem balanced? And please let me know if my editor goofed up the line endings.