### PR TITLE
Change mass of LqdTrussTank to be 4x 1.8 Kontainter Tank instead of 40x

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/LqdTrussTank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kontainers/LqdTrussTank.cfg
@@ -42,7 +42,7 @@ attachRules = 1,1,1,1,0
 
 
 // --- standard part parameters ---
-mass = 17.5
+mass = 1.75
 dragModelType = default
 maximum_drag = 0.20
 minimum_drag = 0.15
@@ -58,7 +58,7 @@ bulkheadProfiles = size0,srf
 		resourceAmounts = 14000;140000;1400000;1260,1540;14000;14000;14000;56000;2800;2800
  		initialResourceAmounts = 0;35000;350000;0;0;0;0;0;0;0
  		tankCost = 56000000;560000;14700;1288;11.2;224000;0;2058;2240;3360
-		basePartMass = 17.5
+		basePartMass = 1.75
 		tankMass = 0;0;0;0;0;0;0;0;0;0
 		hasGUI = false
 	}


### PR DESCRIPTION
Units to mass ratio was off by an order of magnitude compared to all other Kontainers.  Changed mass to be more in line with 4x 1.8m Kontainer Tank.
