### PR TITLE
Updated Mulch/Fertilizer on Duna Agriculture module

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Duna_Agriculture.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Duna_Agriculture.cfg
@@ -185,7 +185,7 @@ PART
 		INPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio =  0.00014
+			Ratio =  0.00013
 		}
 		OUTPUT_RESOURCE
 		{


### PR DESCRIPTION
To match all the other agroponics ratio, input of Fertilizer on Agroponics Duna should be 0.00013, not 0,00014 as it is now. #960 