### PR TITLE
Added USI_ModuleResourceWarehouse to Ranger Agr.

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_AgModule.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_AgModule.cfg
@@ -367,7 +367,11 @@ PART
 	{
 		name = ModuleWeightDistributableCargo
 	}	
-
+	
+	MODULE
+	{
+		name = USI_ModuleResourceWarehouse
+	}
 	
 	MODULE
 	{


### PR DESCRIPTION
Added USI_ModuleResourceWarehouse to Ranger Agriculture Module, so it's not required to have a storage module in the same vessel to share resources even if they are very low. The way it is now it waits to get to 200 Supplies to start sharing, so this change would allow sharing at any time.