### PR TITLE
Update MKS_CTT.cfg

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/MKS_CTT.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/MKS_CTT.cfg
@@ -160,6 +160,11 @@
 	@TechRequired = logistics
 }
 
+@PART[Ranger_MiniHab]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = shortTermHabitation
+}
+
 @PART[Ranger_MountPoint]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = composites

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/MKS_CTT.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/MKS_CTT.cfg
@@ -150,6 +150,11 @@
 	@TechRequired = shortTermHabitation
 }
 
+@PART[Ranger_HeatPump]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = largeElectrics
+}
+
 @PART[Ranger_ISM]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = logistics
@@ -187,12 +192,12 @@
 
 @PART[SalamanderPod]:NEEDS[CommunityTechTree]
 {
-	@TechRequired = simpleCommandModules
+	@TechRequired = shortTermHabitation
 }
 
 @PART[ScoutLanderMk2]:NEEDS[CommunityTechTree]
 {
-	@TechRequired = simpleCommandModules
+	@TechRequired = shortTermHabitation
 }
 
 @PART[Tundra_250Cap]:NEEDS[CommunityTechTree]


### PR DESCRIPTION
For some reason, some of the CTT changes from pull request #979 are missing, namely:
- Salamander and Scout Lander from 'simpleCommandModules' to 'ShortTermHabitation'.
- Ranger Thermal module added to 'High-Power Electrics'.

I've also added the Ranger_MiniHab to the 'Short Term Habitation Node'.

