### PR TITLE
Dboi88 module weight distributable cargo fixes

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_BatPak.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_BatPak.cfg
@@ -71,4 +71,8 @@ PART
 		maxAmount = 6000
 		isTweakable = True
 	}
+	MODULE
+	{
+		name = ModuleWeightDistributableCargo
+	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_MiniHab.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_MiniHab.cfg
@@ -115,4 +115,8 @@ PART
         carriable = true
         allowAttachOnStatic = false
 	}	
+	MODULE
+	{
+		name = ModuleWeightDistributableCargo
+	}
 }


### PR DESCRIPTION
Once i understood what ModuleWeightDistributableCargo did i noticed it was missing from two of the Ranger parts. I've never done a PR before so please let me know if I've done anything wrong.

Cheers 