### PR TITLE
Ignore ElectricCharge in Planetary Logistic

### DIFF
--- a/Source/KolonyTools/PlanetaryLogistics/ModulePlanetaryLogistics.cs
+++ b/Source/KolonyTools/PlanetaryLogistics/ModulePlanetaryLogistics.cs
@@ -39,7 +39,10 @@ namespace PlanetaryLogistics
 
             foreach (var res in part.Resources.list)
             {
-                LevelResources(res.resourceName);
+                if (res.ResourceName != "ElectricCharge")
+                {
+                    LevelResources(res.resourceName);
+                }
             }
         }
 


### PR DESCRIPTION
I don't know if it  was by design but I've seen electric charge getting pushed into planetary storage.
Please don't take into account if it was intended ;)