### PR TITLE
Removes non-USI EL parts from game

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/EL_USI.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/EL_USI.cfg
@@ -51,3 +51,15 @@ EL_ResourceRecipe:NEEDS[Launchpad] {
 	}
 }
 
+// Remove all extraneous EL parts. All that's needed is the survey stake and mallet.
+
+!PART[*]:HAS[@RESOURCE[Metal]|@RESOURCE[MetalOre]|@RESOURCE[RocketParts]]:AFTER[ExtraplanetaryLaunchpads]
+{
+}
+
+!PART[*]:HAS[@MODULE[ExExtractor]|@MODULE[ExRecycler]|@MODULE[ExConverter]]:AFTER[ExtraplanetaryLaunchpads]
+{
+}
+!PART[exLaunchPad|exLaunchPad2|OMD|ExOrbitalDock|exRunway]:AFTER[ExtraplanetaryLaunchpads]
+{
+}


### PR DESCRIPTION
The documentation recommends removing all the EL parts except for the survey stake and mallet. While this won't save memory, this will prevent the completely separate, parallel set of resource (RocketParts, Metal, MetalOre) containers, extractors and processors from appearing. This had been especially confusing since the stock EL parts show up much earlier in the tech tree than the USI ones.