### PR TITLE
Update MKS.version

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/MKS.version
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/MKS.version
@@ -1,6 +1,6 @@
 {
      "NAME":"UKS",
-	 "URL":"https://raw.githubusercontent.com/BobPalmer/MKS/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/UKS/UKS.version",
+	 "URL":"https://raw.githubusercontent.com/BobPalmer/MKS/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/MKS.version",
 	 "DOWNLOAD":"https://github.com/BobPalmer/MKS/releases",
      "GITHUB":{
          "USERNAME":"BobPalmer",

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/MKS.version
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/MKS.version
@@ -1,5 +1,5 @@
 {
-     "NAME":"UKS",
+     "NAME":"MKS",
 	 "URL":"https://raw.githubusercontent.com/BobPalmer/MKS/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/MKS.version",
 	 "DOWNLOAD":"https://github.com/BobPalmer/MKS/releases",
      "GITHUB":{


### PR DESCRIPTION
I was wondering why I was 5 version behind, KSP-AVC was looking for UmbraSpaceIndustries/UKS/UKS.version which is now MKS.version