### PR TITLE
Add additional categories to Ranger and Tundra OSE workshops

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/OSE.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/OSE.cfg
@@ -27,7 +27,111 @@
 		amount = 0
 		maxAmount = 400
 		isTweakable = True
-	}	
+	}
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Aero
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_advaerodynamics
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Communication
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_advunmanned
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Control
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_largecontrol
+	}
+	
+	MODULE
+  {
+    name = OseModuleCategoryAddon
+    Category = Coupling
+    IconPath = Squad/PartList/SimpleIcons/cs_size3
+  }
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Electrical
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_electrics
+	}
+
+  MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Engine
+		IconPath = Squad/PartList/SimpleIcons/RDicon_propulsionSystems
+	}
+
+  MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = FuelTank
+		IconPath = Squad/PartList/SimpleIcons/RDicon_fuelSystems-advanced
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Ground
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_advancedmotors
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Payload
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_composites
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Pods
+		IconPath = Squad/PartList/SimpleIcons/RDicon_commandmodules
+	}
+	
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Science
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_advsciencetech
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Structural
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_generalconstruction
+	}
+
+  	MODULE
+  	{
+    		name = OseModuleCategoryAddon
+    		Category = Thermal
+    		IconPath = Squad/PartList/SimpleIcons/fuels_monopropellant
+  	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Utility
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_generic
+	}
+	
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = none
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_robotics
+	}
   
 }
 
@@ -59,7 +163,111 @@
 		amount = 0
 		maxAmount = 100
 		isTweakable = True
-	}	
+	}
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Aero
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_advaerodynamics
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Communication
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_advunmanned
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Control
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_largecontrol
+	}
+	
+	MODULE
+  {
+    name = OseModuleCategoryAddon
+    Category = Coupling
+    IconPath = Squad/PartList/SimpleIcons/cs_size3
+  }
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Electrical
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_electrics
+	}
+
+  MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Engine
+		IconPath = Squad/PartList/SimpleIcons/RDicon_propulsionSystems
+	}
+
+  MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = FuelTank
+		IconPath = Squad/PartList/SimpleIcons/RDicon_fuelSystems-advanced
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Ground
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_advancedmotors
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Payload
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_composites
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Pods
+		IconPath = Squad/PartList/SimpleIcons/RDicon_commandmodules
+	}
+	
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Science
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_advsciencetech
+	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Structural
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_generalconstruction
+	}
+
+  	MODULE
+  	{
+    		name = OseModuleCategoryAddon
+    		Category = Thermal
+    		IconPath = Squad/PartList/SimpleIcons/fuels_monopropellant
+  	}
+
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = Utility
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_generic
+	}
+	
+	MODULE
+	{
+		name = OseModuleCategoryAddon
+		Category = none
+		IconPath = Squad/PartList/SimpleIcons/R&D_node_icon_robotics
+	}
   
 }
 


### PR DESCRIPTION
By default they only have power, communication and science categories which is very limited. I know you were planing on using OSE (if you don't implement something similar yourself) to build bases and it'd be basically useless in that regard without these additions.