### PR TITLE
Part Description Alterations

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Duna_LogCenter.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Duna_LogCenter.cfg
@@ -33,7 +33,7 @@ PART
 	subcategory = 0
 	title = MKS 'Duna' Logistics Center
 	manufacturer = USI - Kolonization Division
-	description = The Logistics Center allows the vessel (and the resource warehouses attached directly to it) to participate in planetary logistics, taking or storing resources in platetary stockpiles.
+	description = The Logistics Center allows the vessel (and the resource warehouses attached directly to it) to participate in planetary logistics, taking or storing resources in planetary stockpiles.
 	
 	tags = USI MKS Duna Crew Hatch ?eva ?iva Control command base lander station colony warehouse stor stock resource planet work ScienceContainer logistics Kerbal repair ReplacementParts LifeSupport liv ElectricCharge e/c 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Agriculture250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Agriculture250.cfg
@@ -25,7 +25,7 @@ PART
 	subcategory = 0
 	title = MKS 'Tundra' Agriculture Module (2.5m)
 	manufacturer = USI - Kolonization Division
-	description = This module brings more advanced farming techniques to your colony.  While it's own space is limited, it can take advantage of other more expansive modules to help replenish your supplies through a variety of agriculture options.
+	description = The MKS Tundra Agriculture module can be configured as an Agroponics Unit, Cultivator, or Agricultural unit, allowing a variety of configurations to produce supplies and/or organics.
 	
 	tags = USI MKS Tundra Crew ?iva Control command base utility colony agriculture farm agroponics greenhouse resource convert cultivate bio recyc KIS swap cargo weight logistics MKS ScienceContainter LifeSupport Kerbal algae expand bay Recycle ReplacementParts LifeSupport Substrate MaterialKits Supplies Ore Recyclables SpecializedParts Fertilizer Dirt Organics Water Mulch ElectricCharge e/c 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Agriculture375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Agriculture375.cfg
@@ -26,7 +26,7 @@ PART
 	subcategory = 0
 	title = MKS 'Tundra' Agriculture Module (3.75m)
 	manufacturer = USI - Kolonization Division
-	description = This module brings more advanced farming techniques to your colony.  While it's own space is limited, it can take advantage of other more expansive modules to help replenish your supplies through a variety of agriculture options.
+	description = The MKS Tundra Agriculture module can be configured as an Agroponics Unit, Cultivator, or Agricultural unit, allowing a variety of configurations to produce supplies and/or organics.
 	
 	tags = USI MKS Tundra Crew ?iva Control command base utility colony agriculture farm agroponics greenhouse resource convert cultivate bio recyc KIS swap cargo weight logistics MKS ScienceContainter LifeSupport Kerbal algae expand bay Recycle ReplacementParts LifeSupport Substrate MaterialKits Supplies Ore Recyclables SpecializedParts Fertilizer Dirt Organics Water Mulch ElectricCharge e/c 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_NukeProc.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_NukeProc.cfg
@@ -27,7 +27,7 @@ PART
 	title = MKS 'Tundra' Nuclear Fuel Plant
 	manufacturer = USI - Manufacturing Division
 	//description = A field training center for training your Kerbonauts.  When training is conducted, attendees will gain experience based on the instructors present, and in their chosen field.  Up to one star when used on Kerbin, two stars while in orbit, and three stars if training takes place landed on another planet or moon.
-	description = Processing plant for nuclear fuel production and refinement.  The centrifuge processes Uraninite using machines spinning really fast and produces EnrichedUranium.  DepletedFuel can also be reprocessed with USI Breeder technology, coaxing out every bit of EnrichedUranium left in the fuel. Sutible for interplanetary operations, spacecraft, stations, and surface bases (radiators not included.) Centrifuge not suitable for Kerbal entertainment purposes
+	description = Processing plant for nuclear fuel production and refinement.  The centrifuge processes Uraninite using machines spinning really fast and produces EnrichedUranium.  DepletedFuel can also be reprocessed with USI Breeder technology, coaxing out every bit of EnrichedUranium left in the fuel. Suitable for interplanetary operations, spacecraft, stations, and surface bases (radiators not included.) Centrifuge not suitable for Kerbal entertainment purposes.
 
 	tags = USI MKS Tundra Crew ?iva Control command base utility station convert colony coloni nuclear centrifuge breed plant fuel sciencecontainer repair resource swap bay Recycle ReplacementParts LifeSupport liv Uraninite Ore Recyclables SpecializedParts EnrichedUranium DepletedFuel ElectricCharge e/c 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_PioneerLC.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_PioneerLC.cfg
@@ -25,7 +25,7 @@ PART
 	subcategory = 0
 	title = MKS 'Tundra' Pioneer - Logistics Module
 	manufacturer = USI - Kolonization Division
-	description = Designed to be one of the first parts of a long term colony, the Pioneer module features local logistics capabilities, basic training facilities, recycling facilities for life support, KerbNet access, and survey station capabilities for off-world construction.  Includes Logistics functionality that allows the vessel (and the resource warehouses attached directly to it) to participate in planetary logistics, taking or storing resources in platetary stockpiles.
+	description = Designed to be one of the first parts of a long term colony, the Pioneer module features local logistics capabilities, basic training facilities, recycling facilities for life support, KerbNet access, and survey station capabilities for off-world construction.  Includes Logistics functionality that allows the vessel (and the resource warehouses attached directly to it) to participate in planetary logistics, taking or storing resources in planetary stockpiles.
 
 	tags = USI MKS Tundra Crew ?iva Control command base lander station colony coloni warehouse logistics planet train KerbNet survey workshop terrain biome experience manage repair Recycle ReplacementParts LifeSupport liv Ore Recyclables ElectricCharge e/c 
 


### PR DESCRIPTION
Both Tundra and Duna modules had "platetary" instead of "planetary" in their descriptions.