### PR TITLE
Add attachment node to MiniDrill

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/StockTweaks.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/StockTweaks.cfg
@@ -40,3 +40,10 @@
 		}
 	}	
 }
+
+@PART[MiniDrill]
+{
+	// Make node-attachable like MKS_Drill_01
+	@attachRules = 1,1,0,0,0
+	node_stack_back = .2, .05, 0, 1, 0, 0, 1
+}


### PR DESCRIPTION
`MKS_Drill_01` has a "back" attachment node, which is helpful for attaching it precisely to trusses with KIS.  This change patches the stock `MiniDrill` (on which `MKS_Drill_01` is based) to have a similar attachment node.

Since the stock drill is smaller than the MKS one, the attachment node on the stock one is positioned a bit higher so that the two drills have roughly the same ground clearance when extended.