### PR TITLE
Update texture paths for button icons

### DIFF
--- a/Source/KolonyTools/KolonyTools/Kolonization/KolonizationMonitor.cs
+++ b/Source/KolonyTools/KolonyTools/Kolonization/KolonizationMonitor.cs
@@ -106,7 +106,7 @@ namespace KolonyTools
             if (ToolbarManager.ToolbarAvailable)
             {
                 this.kolonyTButton = ToolbarManager.Instance.add("UKS", "kolony");
-                kolonyTButton.TexturePath = "UmbraSpaceIndustries/Kolonization/Kolony24";
+                kolonyTButton.TexturePath = "UmbraSpaceIndustries/MKS/Kolony24";
                 kolonyTButton.ToolTip = "USI Kolony";
                 kolonyTButton.Enabled = true;
                 kolonyTButton.OnClick += (e) => { if(windowVisible) { GuiOff(); windowVisible = false; } else { GuiOn(); windowVisible = true; } };

--- a/Source/KolonyTools/KolonyTools/OrbitalLogistics/MKSLlocal.cs
+++ b/Source/KolonyTools/KolonyTools/OrbitalLogistics/MKSLlocal.cs
@@ -29,7 +29,7 @@ namespace KolonyTools
         //    if (ToolbarManager.ToolbarAvailable)
         //    {
         //        this.orbLogTButton = ToolbarManager.Instance.add("UKS", "orbLog");
-        //        orbLogTButton.TexturePath = "UmbraSpaceIndustries/Kolonization/OrbitalLogistics24";
+        //        orbLogTButton.TexturePath = "UmbraSpaceIndustries/MKS/OrbitalLogistics24";
         //        orbLogTButton.ToolTip = "USI Orbital Logistics";
         //        orbLogTButton.Enabled = true;
         //        orbLogTButton.OnClick += (e) => { if (windowVisible) { GuiOff(); windowVisible = false; } else { GuiOn(); windowVisible = true; } };

--- a/Source/KolonyTools/KolonyTools/StationManager/StationManager.old
+++ b/Source/KolonyTools/KolonyTools/StationManager/StationManager.old
@@ -26,7 +26,7 @@ namespace KolonyTools
         //    if (ToolbarManager.ToolbarAvailable)
         //    {
         //        this.stationTButton = ToolbarManager.Instance.add("UKS", "stationManager");
-        //        stationTButton.TexturePath = "UmbraSpaceIndustries/Kolonization/StationManager24";
+        //        stationTButton.TexturePath = "UmbraSpaceIndustries/MKS/StationManager24";
         //        stationTButton.ToolTip = "USI Station Manager";
         //        stationTButton.Enabled = true;
         //        stationTButton.OnClick += (e) => { if(windowVisible) { GuiOff(); windowVisible = false; } else { GuiOn(); windowVisible = true; } };

--- a/Source/KolonyTools/KolonyTools/UI/Kolonization_UI.cs
+++ b/Source/KolonyTools/KolonyTools/UI/Kolonization_UI.cs
@@ -47,7 +47,7 @@ namespace Kolonization
             if (ToolbarManager.ToolbarAvailable)
             {
                 this.kolonyTButton = ToolbarManager.Instance.add("UKS", "kolony");
-                kolonyTButton.TexturePath = "UmbraSpaceIndustries/Kolonization/Kolony24";
+                kolonyTButton.TexturePath = "UmbraSpaceIndustries/MKS/Kolony24";
                 kolonyTButton.ToolTip = "USI Kolony";
                 kolonyTButton.Enabled = true;
                 kolonyTButton.OnClick += (e) => { if(windowVisible) { GuiOff(); windowVisible = false; } else { GuiOn(); windowVisible = true; } };


### PR DESCRIPTION
Everything has moved from "Kolonization" to "MKS", but the icons for the
buttons for the Toolbar mod were not notified.

Fixes #1035 