### PR TITLE
Add Scout weight transfer to small KIS container

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/KIS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/KIS.cfg
@@ -1,0 +1,15 @@
+@PART[KIS_ContainerMount1]
+{
+	MODULE
+	{
+		name = ModuleWeightDistributableCargo
+	}
+}
+
+@PART[KIS_Container1]
+{
+	MODULE
+	{
+		name = ModuleWeightDistributableCargo
+	}
+}


### PR DESCRIPTION
The SC-62 container from KIS is similar in size to the radial Ranger parts, and it can be useful to attach one to a Scout lander, so it should support the Scout's "weight transfer" feature like the Ranger parts do.

Weight transfer only seems to work for parts that are directly attached to the Scout; it doesn't work if the SC-62 container is mounted on an SM-62 container mount.  But I've added weight transfer support to the SM-62 as well, because it's very small and light and it makes sense for it to support weight transfer at least when it's "empty".

(This is related to #1108 and #1109.)