### PR TITLE
Drill descriptions & improve MPU mechanics

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02.cfg
@@ -24,7 +24,7 @@ PART
 	subcategory = 0
 	title = MEU-500 Pulse Drill
 	manufacturer = USI - Manufacturing Division
-	description = The MEU-500 pulse drill can be used to excavate valuable resources from planetary surfaces.  Swappable drillheads and internal separator configurations allow the drill to focus on specific resources, or pull in all resources for later separation.
+	description = The MEU-500 pulse drill can be used to excavate valuable resources from planetary surfaces.  Swappable drillheads and internal separator configurations allow the drill to focus on specific resources, or pull in all resources for later separation. Heat, power and production figures are per drillhead.
 	
 	tags = USI MKS drill MEU pulse resources surface harvester converter thermal heat Uraninite Substrate Minerals ExoticMinerals RareMetals MaterialKits SpecializedParts Hydrates Gypsum Dirt Silicates Water 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02A.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02A.cfg
@@ -24,7 +24,7 @@ PART
 	subcategory = 0
 	title = MEU-500-A Pulse Drill
 	manufacturer = USI - Manufacturing Division
-	description = This automated version of the MEU-500 pulse drill can be used to excavate valuable resources from planetary surfaces.  Swappable drillheads and internal separator configurations allow the drill to focus on specific resources, or pull in all resources for later separation.
+	description = This automated version of the MEU-500 pulse drill can be used to excavate valuable resources from planetary surfaces.  Swappable drillheads and internal separator configurations allow the drill to focus on specific resources, or pull in all resources for later separation. Heat, power and production figures are per drillhead.
 	
 	tags = USI MKS drill MEU pulse resources surface harvester converter thermal heat Uraninite Substrate Minerals ExoticMinerals RareMetals MaterialKits SpecializedParts Hydrates Gypsum Dirt Silicates Water 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03.cfg
@@ -24,7 +24,7 @@ PART
 	subcategory = 0
 	title = Industrial Strip Miner
 	manufacturer = USI - Manufacturing Division
-	description = This industrial strip miner can be used to excavate valuable resources from planetary surfaces.  Swappable drillheads and internal separator configurations allow the drill to focus on specific resources, or pull in all resources for later separation. through a variety of changeable drill bits.
+	description = This industrial strip miner can be used to excavate valuable resources from planetary surfaces.  Swappable drillheads and internal separator configurations allow the drill to focus on specific resources, or pull in all resources for later separation. through a variety of changeable drill bits. heat, power and production figures are per drillhead.
 	
 	tags = USI MKS drill industrial miner resources surface harvester converter thermal heat Uraninite Substrate Minerals ExoticMinerals RareMetals MaterialKits SpecializedParts Hydrates Gypsum Dirt Silicates Water 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03A.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03A.cfg
@@ -24,7 +24,7 @@ PART
 	subcategory = 0
 	title = Automated Industrial Strip Miner
 	manufacturer = USI - Manufacturing Division
-	description = This automated industrial strip miner can be used to excavate valuable resources from planetary surfaces.  Swappable drillheads and internal separator configurations allow the drill to focus on specific resources, or pull in all resources for later separation. through a variety of changeable drill bits.
+	description = This automated industrial strip miner can be used to excavate valuable resources from planetary surfaces.  Swappable drillheads and internal separator configurations allow the drill to focus on specific resources, or pull in all resources for later separation. through a variety of changeable drill bits. Heat, power and production figures are per drillhead.
 	
 	tags = USI MKS drill industrial miner resources surface harvester converter thermal heat Uraninite Substrate Minerals ExoticMinerals RareMetals MaterialKits SpecializedParts Hydrates Gypsum Dirt Silicates Water 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor125.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor125.cfg
@@ -44,16 +44,40 @@ PART
 
 	MODULE
 	{
+		name = ModuleOverheatDisplay	
+	}
+	MODULE
+	{
 		name = ModuleResourceConverter_USI
-		ConverterName = LiquidFuel
-		StartActionName = Start LiquidFuel
-		StopActionName = Stop LiquidFuel
-		Efficiency = 1	
-
+		ConverterName = LFO
+		StartActionName = Start LFO
+		StopActionName = Stop LFO
+		Efficiency = 1
+		AutoShutdown = true
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 10000
+			key = 500 5000
+			key = 1000 2500
+			key = 1250 2500
+			key = 1500 500
+			key = 2000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.25
+			key = 1000 1.0
+			key = 1250 0.5
+			key = 1500 0.1
+			key = 2000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio =  0.0013
+			Ratio =  0.013
 		}
 		INPUT_RESOURCE
 		{
@@ -63,7 +87,75 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = LiquidFuel
-			Ratio = 0.00026
+			Ratio = 0.00117
+			DumpExcess = False
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxidizer
+			Ratio = 0.00143
+			DumpExcess = False
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.0000018
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.0000018
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 90
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleResourceConverter_USI
+		ConverterName = LiquidFuel
+		StartActionName = Start LiquidFuel
+		StopActionName = Stop LiquidFuel
+		Efficiency = 1
+		AutoShutdown = true
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 10000
+			key = 500 5000
+			key = 1000 2500
+			key = 1250 2500
+			key = 1500 500
+			key = 2000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.25
+			key = 1000 1.0
+			key = 1250 0.5
+			key = 1500 0.1
+			key = 2000 0
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Ore
+			Ratio =  0.013
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1.56
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = LiquidFuel
+			Ratio = 0.0026
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
@@ -91,11 +183,31 @@ PART
 		StartActionName = Start Oxidizer
 		StopActionName = Stop Oxidizer
 		Efficiency = 1	
-
+		AutoShutdown = true
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 10000
+			key = 500 5000
+			key = 1000 2500
+			key = 1250 2500
+			key = 1500 500
+			key = 2000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.25
+			key = 1000 1.0
+			key = 1250 0.5
+			key = 1500 0.1
+			key = 2000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio =  0.0013
+			Ratio =  0.013
 		}
 		INPUT_RESOURCE
 		{
@@ -105,7 +217,7 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Oxidizer
-			Ratio = 0.00026
+			Ratio = 0.0026
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
@@ -133,11 +245,30 @@ PART
 		StartActionName = Start MonoPropellant
 		StopActionName = Stop MonoPropellant
 		Efficiency = 1	
-
+		AutoShutdown = true
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		{
+			key = 0 10000
+			key = 500 5000
+			key = 1000 2500
+			key = 1250 2500
+			key = 1500 500
+			key = 2000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.25
+			key = 1000 1.0
+			key = 1250 0.5
+			key = 1500 0.1
+			key = 2000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio =  0.0013
+			Ratio =  0.013
 		}
 		
 		INPUT_RESOURCE
@@ -149,7 +280,7 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = MonoPropellant
-			Ratio = 0.00026
+			Ratio = 0.0026
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
@@ -177,7 +308,27 @@ PART
 		StartActionName = Start Minerals
 		StopActionName = Stop Minerals
 		Efficiency = 1	
-
+		AutoShutdown = true
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 10000
+			key = 500 5000
+			key = 1000 2500
+			key = 1250 2500
+			key = 1500 500
+			key = 2000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.25
+			key = 1000 1.0
+			key = 1250 0.5
+			key = 1500 0.1
+			key = 2000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Minerals
@@ -219,7 +370,27 @@ PART
 		StartActionName = Start Metals
 		StopActionName = Stop Metals
 		Efficiency = 1	
-
+		AutoShutdown = true
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 10000
+			key = 500 5000
+			key = 1000 2500
+			key = 1250 2500
+			key = 1500 500
+			key = 2000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.25
+			key = 1000 1.0
+			key = 1250 0.5
+			key = 1500 0.1
+			key = 2000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = MetallicOre
@@ -261,7 +432,27 @@ PART
 		StartActionName = Start Polymers
 		StopActionName = Stop Polymers
 		Efficiency = 1	
-
+		AutoShutdown = true
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 10000
+			key = 500 5000
+			key = 1000 2500
+			key = 1250 2500
+			key = 1500 500
+			key = 2000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.25
+			key = 1000 1.0
+			key = 1250 0.5
+			key = 1500 0.1
+			key = 2000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Substrate
@@ -303,7 +494,27 @@ PART
 		StartActionName = Start Fertilizer(G)
 		StopActionName = Stop Fertilizer(G)
 		Efficiency = 1	
-	
+		AutoShutdown = true
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 10000
+			key = 500 5000
+			key = 1000 2500
+			key = 1250 2500
+			key = 1500 500
+			key = 2000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.25
+			key = 1000 1.0
+			key = 1250 0.5
+			key = 1500 0.1
+			key = 2000 0
+		}	
 		INPUT_RESOURCE
 		{
 			ResourceName = Gypsum
@@ -345,7 +556,27 @@ PART
 		StartActionName = Start Fertilizer(M)
 		StopActionName = Stop Fertilizer(M)
 		Efficiency = 1	
-
+		AutoShutdown = true
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 10000
+			key = 500 5000
+			key = 1000 2500
+			key = 1250 2500
+			key = 1500 500
+			key = 2000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.25
+			key = 1000 1.0
+			key = 1250 0.5
+			key = 1500 0.1
+			key = 2000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Minerals
@@ -380,7 +611,6 @@ PART
 		}
 	}		
 	
-
 	MODULE
 	{
 		name = ModuleEfficiencyPart
@@ -471,8 +701,24 @@ PART
 	MODULE
 	{
 		name = MKSModule
-	}	
-	
+	}
+	MODULE
+	{
+		name = ModuleCoreHeat
+		CoreTempGoal = 1000				//Internal temp goal - we don't transfer till we hit this point
+		CoreToPartRatio = 0.1				//Scale back cooling if the part is this % of core temp
+		CoreTempGoalAdjustment = 0			//Dynamic goal adjustment
+		CoreEnergyMultiplier = 0.1			//What percentage of our core energy do we transfer to the part
+		HeatRadiantMultiplier = 0.25			//If the core is hotter, how much heat radiates?
+		CoolingRadiantMultiplier = 0			//If the core is colder, how much radiates?
+		HeatTransferMultiplier = 0			//If the part is hotter, how much heat transfers in?
+		CoolantTransferMultiplier = 0.01		//If the part is colder, how much of our energy can we transfer?
+		radiatorCoolingFactor = 1			//How much energy we pull from core with an active radiator?  >= 1
+		radiatorHeatingFactor = 0.05			//How much energy we push to the active radiator
+		MaxCalculationWarp = 1000			//Based on how dramatic the changes are, this is the max rate of change
+		CoreShutdownTemp = 2000				//At what core temperature do we shut down all generators on this part?
+		MaxCoolant = 250				//Maximum amount of radiator capacity we can consume - 50 = 1 small
+	}
 	MODULE
 	{
 		name = ModuleSwappableConverter

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor250.cfg
@@ -43,16 +43,40 @@ PART
 
 	MODULE
 	{
+		name = ModuleOverheatDisplay
+	}
+	MODULE
+	{
 		name = ModuleResourceConverter_USI
-		ConverterName = LiquidFuel
-		StartActionName = Start LiquidFuel
-		StopActionName = Stop LiquidFuel
-		Efficiency = 1	
-
+		ConverterName = LFO
+		StartActionName = Start LFO
+		StopActionName = Stop LFO
+		Efficiency = 1
+		EfficiencyBonus = 1
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 500 20000
+			key = 1000 5000
+			key = 1500 2500
+			key = 2000 500
+			key = 3000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 1.0
+			key = 1500 0.25
+			key = 2000 0.1
+			key = 3000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio =  0.0047
+			Ratio =  0.047
 		}
 		INPUT_RESOURCE
 		{
@@ -62,7 +86,13 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = LiquidFuel
-			Ratio = 0.00094
+			Ratio = 0.00423
+			DumpExcess = False
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxidizer
+			Ratio = 0.00517
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
@@ -81,7 +111,68 @@ PART
 			ResourceName = Machinery
 			Ratio = 650
 		}
-	}		
+	}
+
+	MODULE
+	{
+		name = ModuleResourceConverter_USI
+		ConverterName = LiquidFuel
+		StartActionName = Start LiquidFuel
+		StopActionName = Stop LiquidFuel
+		Efficiency = 1	
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 500 20000
+			key = 1000 5000
+			key = 1500 2500
+			key = 2000 500
+			key = 3000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 1.0
+			key = 1500 0.25
+			key = 2000 0.1
+			key = 3000 0
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Ore
+			Ratio =  0.047
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 5.64
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = LiquidFuel
+			Ratio = 0.0094
+			DumpExcess = False
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.0000130
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.0000130
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 650
+		}
+	}
 
 	MODULE
 	{
@@ -90,11 +181,30 @@ PART
 		StartActionName = Start Oxidizer
 		StopActionName = Stop Oxidizer
 		Efficiency = 1	
-
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 500 20000
+			key = 1000 5000
+			key = 1500 2500
+			key = 2000 500
+			key = 3000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 1.0
+			key = 1500 0.25
+			key = 2000 0.1
+			key = 3000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio =  0.0047
+			Ratio =  0.047
 		}
 		INPUT_RESOURCE
 		{
@@ -104,7 +214,7 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Oxidizer
-			Ratio = 0.00094
+			Ratio = 0.0094
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
@@ -123,7 +233,7 @@ PART
 			ResourceName = Machinery
 			Ratio = 650
 		}
-	}		
+	}
 
 	MODULE
 	{
@@ -132,11 +242,30 @@ PART
 		StartActionName = Start MonoPropellant
 		StopActionName = Stop MonoPropellant
 		Efficiency = 1	
-
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 500 20000
+			key = 1000 5000
+			key = 1500 2500
+			key = 2000 500
+			key = 3000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 1.0
+			key = 1500 0.25
+			key = 2000 0.1
+			key = 3000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio =  0.0047
+			Ratio =  0.047
 		}
 		INPUT_RESOURCE
 		{
@@ -146,7 +275,7 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = MonoPropellant
-			Ratio = 0.00094
+			Ratio = 0.0094
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
@@ -166,8 +295,7 @@ PART
 			Ratio = 650
 		}
 	}			
-	
-	
+		
 	MODULE
 	{
 		name = ModuleResourceConverter_USI
@@ -175,7 +303,26 @@ PART
 		StartActionName = Start Minerals
 		StopActionName = Stop Minerals
 		Efficiency = 1	
-
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 500 20000
+			key = 1000 5000
+			key = 1500 2500
+			key = 2000 500
+			key = 3000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 1.0
+			key = 1500 0.25
+			key = 2000 0.1
+			key = 3000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Minerals
@@ -217,7 +364,26 @@ PART
 		StartActionName = Start Metals
 		StopActionName = Stop Metals
 		Efficiency = 1	
-
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 500 20000
+			key = 1000 5000
+			key = 1500 2500
+			key = 2000 500
+			key = 3000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 1.0
+			key = 1500 0.25
+			key = 2000 0.1
+			key = 3000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = MetallicOre
@@ -259,7 +425,26 @@ PART
 		StartActionName = Start Polymers
 		StopActionName = Stop Polymers
 		Efficiency = 1	
-
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 500 20000
+			key = 1000 5000
+			key = 1500 2500
+			key = 2000 500
+			key = 3000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 1.0
+			key = 1500 0.25
+			key = 2000 0.1
+			key = 3000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Substrate
@@ -301,7 +486,26 @@ PART
 		StartActionName = Start Fertilizer(G)
 		StopActionName = Stop Fertilizer(G)
 		Efficiency = 1	
-	
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 500 20000
+			key = 1000 5000
+			key = 1500 2500
+			key = 2000 500
+			key = 3000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 1.0
+			key = 1500 0.25
+			key = 2000 0.1
+			key = 3000 0
+		}	
 		INPUT_RESOURCE
 		{
 			ResourceName = Gypsum
@@ -343,7 +547,26 @@ PART
 		StartActionName = Start Fertilizer(M)
 		StopActionName = Stop Fertilizer(M)
 		Efficiency = 1	
-
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 500 20000
+			key = 1000 5000
+			key = 1500 2500
+			key = 2000 500
+			key = 3000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 1.0
+			key = 1500 0.25
+			key = 2000 0.1
+			key = 3000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Minerals
@@ -378,7 +601,6 @@ PART
 		}
 	}		
 	
-
 	MODULE
 	{
 		name = ModuleEfficiencyPart
@@ -410,9 +632,7 @@ PART
 			Ratio = 0.0000130
 			DumpExcess = true
 		}
-	}			
-	
-	
+	}	
 	
 	MODULE
 	{
@@ -469,8 +689,24 @@ PART
 	MODULE
 	{
 		name = MKSModule
+	}
+	MODULE
+	{
+		name = ModuleCoreHeat
+		CoreTempGoal = 1000				//Internal temp goal - we don't transfer till we hit this point
+		CoreToPartRatio = 0.1				//Scale back cooling if the part is this % of core temp
+		CoreTempGoalAdjustment = 0			//Dynamic goal adjustment
+		CoreEnergyMultiplier = 0.1			//What percentage of our core energy do we transfer to the part
+		HeatRadiantMultiplier = 0.25			//If the core is hotter, how much heat radiates?
+		CoolingRadiantMultiplier = 0			//If the core is colder, how much radiates?
+		HeatTransferMultiplier = 0			//If the part is hotter, how much heat transfers in?
+		CoolantTransferMultiplier = 0.01		//If the part is colder, how much of our energy can we transfer?
+		radiatorCoolingFactor = 1			//How much energy we pull from core with an active radiator?  >= 1
+		radiatorHeatingFactor = 0.05			//How much energy we push to the active radiator
+		MaxCalculationWarp = 1000			//Based on how dramatic the changes are, this is the max rate of change
+		CoreShutdownTemp = 3000				//At what core temperature do we shut down all generators on this part?
+		MaxCoolant = 500				//Maximum amount of radiator capacity we can consume - 50 = 1 small
 	}	
-	
 	MODULE
 	{
 		name = ModuleSwappableConverter

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor375.cfg
@@ -43,16 +43,41 @@ PART
 
 	MODULE
 	{
+		name = ModuleOverheatDisplay
+	}
+	MODULE
+	{
 		name = ModuleResourceConverter_USI
-		ConverterName = LiquidFuel
-		StartActionName = Start LiquidFuel
-		StopActionName = Stop LiquidFuel
-		Efficiency = 1	
-
+		ConverterName = LFO
+		StartActionName = Start LFO
+		StopActionName = Stop LFO
+		Efficiency = 1
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 500 50000
+			key = 1000 10000
+			key = 1500 10000
+			key = 2000 2500
+			key = 3000 500
+			key = 4000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 0.25
+			key = 1500 1.0
+			key = 2000 0.5
+			key = 3000 0.1
+			key = 4000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio =  0.01
+			Ratio =  0.1
 		}
 		INPUT_RESOURCE
 		{
@@ -62,7 +87,77 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = LiquidFuel
-			Ratio = 0.002
+			Ratio = 0.009
+			DumpExcess = False
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxidizer
+			Ratio = 0.011
+			DumpExcess = False
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.00004
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.00004
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 2000
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleResourceConverter_USI
+		ConverterName = LiquidFuel
+		StartActionName = Start LiquidFuel
+		StopActionName = Stop LiquidFuel
+		Efficiency = 1
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 500 50000
+			key = 1000 10000
+			key = 1500 10000
+			key = 2000 2500
+			key = 3000 500
+			key = 4000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 0.25
+			key = 1500 1.0
+			key = 2000 0.5
+			key = 3000 0.1
+			key = 4000 0
+			key = 4000 0
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Ore
+			Ratio =  0.1
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 12
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = LiquidFuel
+			Ratio = 0.02
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
@@ -89,12 +184,33 @@ PART
 		ConverterName = Oxidizer
 		StartActionName = Start Oxidizer
 		StopActionName = Stop Oxidizer
-		Efficiency = 1	
-
+		Efficiency = 1
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 500 50000
+			key = 1000 10000
+			key = 1500 10000
+			key = 2000 2500
+			key = 3000 500
+			key = 4000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 0.25
+			key = 1500 1.0
+			key = 2000 0.5
+			key = 3000 0.1
+			key = 4000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio =  0.01
+			Ratio =  0.1
 		}
 		INPUT_RESOURCE
 		{
@@ -104,7 +220,7 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Oxidizer
-			Ratio = 0.002
+			Ratio = 0.02
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
@@ -131,12 +247,33 @@ PART
 		ConverterName = MonoPropellant
 		StartActionName = Start MonoPropellant
 		StopActionName = Stop MonoPropellant
-		Efficiency = 1	
-
+		Efficiency = 1
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 500 50000
+			key = 1000 10000
+			key = 1500 10000
+			key = 2000 2500
+			key = 3000 500
+			key = 4000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 0.25
+			key = 1500 1.0
+			key = 2000 0.5
+			key = 3000 0.1
+			key = 4000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio =  0.01
+			Ratio =  0.1
 		}
 		INPUT_RESOURCE
 		{
@@ -146,7 +283,7 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = MonoPropellant
-			Ratio = 0.002
+			Ratio = 0.02
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
@@ -174,7 +311,28 @@ PART
 		StartActionName = Start Minerals
 		StopActionName = Stop Minerals
 		Efficiency = 1	
-
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 500 50000
+			key = 1000 10000
+			key = 1500 10000
+			key = 2000 2500
+			key = 3000 500
+			key = 4000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 0.25
+			key = 1500 1.0
+			key = 2000 0.5
+			key = 3000 0.1
+			key = 4000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Minerals
@@ -215,8 +373,29 @@ PART
 		ConverterName = Metals
 		StartActionName = Start Metals
 		StopActionName = Stop Metals
-		Efficiency = 1	
-
+		Efficiency = 1
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 500 50000
+			key = 1000 10000
+			key = 1500 10000
+			key = 2000 2500
+			key = 3000 500
+			key = 4000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 0.25
+			key = 1500 1.0
+			key = 2000 0.5
+			key = 3000 0.1
+			key = 4000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = MetallicOre
@@ -257,8 +436,29 @@ PART
 		ConverterName = Polymers
 		StartActionName = Start Polymers
 		StopActionName = Stop Polymers
-		Efficiency = 1	
-
+		Efficiency = 1
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 500 50000
+			key = 1000 10000
+			key = 1500 10000
+			key = 2000 2500
+			key = 3000 500
+			key = 4000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 0.25
+			key = 1500 1.0
+			key = 2000 0.5
+			key = 3000 0.1
+			key = 4000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Substrate
@@ -299,8 +499,29 @@ PART
 		ConverterName = Fertilizer(G)
 		StartActionName = Start Fertilizer(G)
 		StopActionName = Stop Fertilizer(G)
-		Efficiency = 1	
-	
+		Efficiency = 1
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 500 50000
+			key = 1000 10000
+			key = 1500 10000
+			key = 2000 2500
+			key = 3000 500
+			key = 4000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 0.25
+			key = 1500 1.0
+			key = 2000 0.5
+			key = 3000 0.1
+			key = 4000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Gypsum
@@ -341,8 +562,29 @@ PART
 		ConverterName = Fertilizer(M)
 		StartActionName = Start Fertilizer(M)
 		StopActionName = Stop Fertilizer(M)
-		Efficiency = 1	
-
+		Efficiency = 1
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 500 50000
+			key = 1000 10000
+			key = 1500 10000
+			key = 2000 2500
+			key = 3000 500
+			key = 4000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 0.25
+			key = 1500 1.0
+			key = 2000 0.5
+			key = 3000 0.1
+			key = 4000 0
+		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Minerals
@@ -469,7 +711,23 @@ PART
 	{
 		name = MKSModule
 	}	
-	
+	MODULE
+	{
+		name = ModuleCoreHeat
+		CoreTempGoal = 1500				//Internal temp goal - we don't transfer till we hit this point
+		CoreToPartRatio = 0.1				//Scale back cooling if the part is this % of core temp
+		CoreTempGoalAdjustment = 0			//Dynamic goal adjustment
+		CoreEnergyMultiplier = 0.1			//What percentage of our core energy do we transfer to the part
+		HeatRadiantMultiplier = 0.25			//If the core is hotter, how much heat radiates?
+		CoolingRadiantMultiplier = 0			//If the core is colder, how much radiates?
+		HeatTransferMultiplier = 0			//If the part is hotter, how much heat transfers in?
+		CoolantTransferMultiplier = 0.01		//If the part is colder, how much of our energy can we transfer?
+		radiatorCoolingFactor = 1			//How much energy we pull from core with an active radiator?  >= 1
+		radiatorHeatingFactor = 0.05			//How much energy we push to the active radiator
+		MaxCalculationWarp = 1000			//Based on how dramatic the changes are, this is the max rate of change
+		CoreShutdownTemp = 4000				//At what core temperature do we shut down all generators on this part?
+		MaxCoolant = 1000				//Maximum amount of radiator capacity we can consume - 50 = 1 small
+	}
 	MODULE
 	{
 		name = ModuleSwappableConverter

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kerbitat250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kerbitat250.cfg
@@ -63,7 +63,6 @@ PART
 		reverseVisibility = true		
 	}	
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kerbitat375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kerbitat375.cfg
@@ -78,7 +78,6 @@ PART
 		attachNodeNames = 125bottom
 	}	
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand


### PR DESCRIPTION
Extended drill descriptions to clear up confusion. Also removed the "base" tag from the Kerbitats.

EXTENDED: Added heat mechanics onto the MPUs as well as creating a new LFO mode and increasing LF/OX/LFO/MP output by the stated 900%. Note that the 2.5m is a little slow to start, owing to a bug with the Unity float curve that meant it didn't work over a certain value (see thread p74).