### PR TITLE
Remove Part Deletion - Alternatives depreciated.

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/EL_USI.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/EL_USI.cfg
@@ -50,28 +50,3 @@ EL_ResourceRecipe:NEEDS[Launchpad] {
 		MonoPropellant = 1
 	}
 }
-
-//remove needless EL parts
-//config by theRagingIrishman
-
-!PART[ELTank*MTL]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[ELTank*ORE]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[ELTank*RP]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-
-!PART[Auger]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[SmallAuger]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[TinyAuger]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-
-!PART[HexCanMetal*]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[HexCanOre*]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[HexCanRocketParts*]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[Rocketparts*7x]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-
-!PART[Magnetometer]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[OMD]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-
-!PART[RocketBuilder]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-
-!PART[Smelter]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[SmallSmelter]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[TinySmelter]:NEEDS[Launchpad]:AFTER[Launchpad] {}


### PR DESCRIPTION
Since EL is being depreciated and the MKS-specific parts are currently depreciated, letting people use the default EL parts would be nice - as there are no alternatives.  (Without third-party mods, of course.)

The rest of the config works and lets people use the MKS resource chain with EL.  I say leave that and treat it like the TAC-LS config: It's shipped, and if people submit PR's it'll be updated, but no effort is made on your part to keep it up to date.