### PR TITLE
fix output resource for Fertilizer(G) mode

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor250.cfg
@@ -314,8 +314,8 @@ PART
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Chemicals
-			Ratio = 0.006
+			ResourceName = Fertilizer
+			Ratio = 0.00148
 			DumpExcess = False
 		}
 		INPUT_RESOURCE

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor375.cfg
@@ -313,8 +313,8 @@ PART
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = Chemicals
-			Ratio = 0.003
+			ResourceName = Fertilizer
+			Ratio = 0.00315
 			DumpExcess = False
 		}
 		INPUT_RESOURCE


### PR DESCRIPTION
Hi BobPalmer,

first of all, thank you for your amazing work! I really enjoy your mods!

I noticed that the 2.5m and 3.75m Material Processing Units from your latest release were set up to produce Chemicals from Gypsum in Fertilizer (G) mode. I switched the output resource to Fertilizer and used the efficiency ratio of Fertilizer (M) to Fertilizer (G) from the 1.25m version to set the efficiency. I hope this is correct.

Maybe you'll find this fix usefull and integrate in a future release.

Greetings,
Damian