### PR TITLE
Move Governor to the MKSModule

### DIFF
--- a/Source/KolonyTools/KolonyTools/MKSModule.cs
+++ b/Source/KolonyTools/KolonyTools/MKSModule.cs
@@ -219,12 +219,19 @@ namespace KolonyTools
 
         public override string GetInfo()
         {
-            if (string.IsNullOrEmpty(eTag))
-                return string.Empty;
-
             var output = new StringBuilder("");
-            output.Append(string.Format("Efficiency Tag: {0}\n", eTag));
-            output.Append(string.Format("Multiplier: {0:0.00}\n", eMultiplier));
+
+            output.Append("Benefits from bonuses:\n");
+            output.Append("  Geology Research\n");
+            if (BonusEffect == "RepBoost")
+                output.Append("  Kolonization Research\n");
+            else if (BonusEffect == "ScienceBoost")
+                output.Append("  Botany Research\n");
+            if (!string.IsNullOrEmpty(eTag))
+            {
+                output.Append("Benefits from Efficiency Parts:\n");
+                output.Append(string.Format("  {0} (consumption {1})\n", eTag, eMultiplier));
+            }
             return output.ToString();
         }
 

--- a/Source/KolonyTools/KolonyTools/MKSModule.cs
+++ b/Source/KolonyTools/KolonyTools/MKSModule.cs
@@ -17,6 +17,9 @@ namespace KolonyTools
         [KSPField]
         public float eMultiplier = 1f;
 
+        [KSPField(guiName = "Governor", isPersistant = true, guiActive = true, guiActiveEditor = false), UI_FloatRange(stepIncrement = 0.1f, maxValue = 1f, minValue = 0f)]
+        public float Governor = 1.0f;
+
         private double lastCheck;
         private double checkTime = 5f;
 
@@ -189,8 +192,11 @@ namespace KolonyTools
             var rate = GetEfficiencyBonus();
             foreach (var con in _bonusConsumerConverters)
             {
-                if(con.useEfficiencyBonus)
-                    con.SetEfficiencyBonus("MKS",rate);
+                if (con.useEfficiencyBonus)
+                {
+                    con.SetEfficiencyBonus("MKS", rate);
+                }
+                con.SetEfficiencyBonus("GOV", Governor);
             }
         }
 

--- a/Source/KolonyTools/KolonyTools/ModuleEfficiencyPart.cs
+++ b/Source/KolonyTools/KolonyTools/ModuleEfficiencyPart.cs
@@ -13,7 +13,6 @@ namespace KolonyTools
         [KSPField]
         public string eTag = "";
 
-        [KSPField(guiName = "Governor", isPersistant = true, guiActive = true, guiActiveEditor = false), UI_FloatRange(stepIncrement = 0.1f, maxValue = 1f, minValue = 0f)]
         public float Governor = 1.0f;
 
         private double _curMult;

--- a/Source/KolonyTools/KolonyTools/ModuleEfficiencyPart.cs
+++ b/Source/KolonyTools/KolonyTools/ModuleEfficiencyPart.cs
@@ -15,6 +15,14 @@ namespace KolonyTools
 
         public float Governor = 1.0f;
 
+        public override string GetInfo()
+        {
+            if (string.IsNullOrEmpty(eTag))
+                return string.Empty;
+            return "Boosts efficiency of converters benefiting from a " + eTag + "\n\n" +
+                "Boost power: " + eMultiplier.ToString();
+        }
+
         private double _curMult;
 
         public double EfficiencyMultiplier


### PR DESCRIPTION
... so that it can limit the load on converters that profit from bonuses.

I removed the one on efficiency parts, as having 2 of them in the interface would be confusing, and that one was not that usefull (if things get wild because you have too many of them, you can just deactivate some completely).

This will appear on some parts that it has no effect on: sifters and efficiency parts configured as efficiency part. But that's more or less equivalent to the one before appearing on efficiency parts configured as converters.