### PR TITLE
Texture Fix in Tundra_Workshop250.cfg

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Workshop250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Workshop250.cfg
@@ -7,7 +7,7 @@ PART
 	MODEL
 	{
 		model = UmbraSpaceIndustries/MKS/Assets/Tundra_250Rigid
-		texture = t28,UmbraSpaceIndustries/MKS/Assets/t28
+		texture = t22,UmbraSpaceIndustries/MKS/Assets/t28
 	}
 	rescaleFactor = 1
 	node_stack_left = 0.0,0.0,1.25,0.0,0.0,1,0


### PR DESCRIPTION
2.5 meter Tundra Workshop displays the Agriculture module's name and number in-game.
This edit fixes that.