### PR TITLE
OSE Material Extractor config fixes

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/OSE.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/OSE.cfg
@@ -422,6 +422,9 @@
 @PART[OSE_Converter]	//Convert the original over to the MKS workflow
 {  
 	-MODULE[ModuleResourceConverter],* {}
+	-RESOURCE[Dirt] {}
+	-RESOURCE[Ore] {}
+
 	MODULE
 	{
 		name = ModuleResourceConverter_USI

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/OSE.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/OSE.cfg
@@ -421,7 +421,7 @@
 //Converter - similar to the workshop's existing functionality
 @PART[OSE_Converter]	//Convert the original over to the MKS workflow
 {  
-	-MODULE[ModuleResourceConverter_USI] {}
+	-MODULE[ModuleResourceConverter],* {}
 	MODULE
 	{
 		name = ModuleResourceConverter_USI

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/OSE.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/OSE.cfg
@@ -421,6 +421,8 @@
 //Converter - similar to the workshop's existing functionality
 @PART[OSE_Converter]	//Convert the original over to the MKS workflow
 {  
+	@description = OSE's Material Extractor refines raw materials into MaterialKits for use in 3D printing.
+
 	-MODULE[ModuleResourceConverter],* {}
 	-RESOURCE[Dirt] {}
 	-RESOURCE[Ore] {}


### PR DESCRIPTION
MKS adds its own production chain to the `OSE_Converter` part, but accidentally left OSE's default Ore-based production chain in place because of a mistake in the MM patch.  I fixed that, and also removed the part's Dirt and Ore storage (since it no longer uses those resources) and changed its description so it doesn't talk about extracting materials from Ore (since it no longer does that).