### PR TITLE
Remove OSE's extra harvesters from stock drills

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/OSE.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/OSE.cfg
@@ -494,3 +494,12 @@
 		isTweakable = True
 	}		
 }
+
+// Stock drills patched by OSE
+@PART[RadialDrill|MiniDrill]:NEEDS[Workshop]:AFTER[Workshop]
+{
+	// MKS provides different drills for these resources
+	-MODULE[ModuleResourceHarvester]:HAS[#ResourceName[Dirt]] {}
+	-MODULE[ModuleResourceHarvester]:HAS[#ResourceName[ExoticMinerals]] {}
+	-MODULE[ModuleResourceHarvester]:HAS[#ResourceName[RareMetals]] {}
+}


### PR DESCRIPTION
OSE Workshop patches the stock drills to be able to extract Dirt, ExoticMinerals, and RareMetals, but MKS provides a separate set of drills for non-Ore resources, so the stock drills should be left alone.