### PR TITLE
Add fore/aft attachment nodes to KER_Hub roof rack

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Hub.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Hub.cfg
@@ -14,7 +14,12 @@ PART
 	node_stack_cargo_RR = -0.35,-1.285,-0.6625,0,1,0,0
 
 	node_stack_rack = 0.0, 0.0, -0.3, 0.0, 0.0, -1.0,1
+	node_stack_rack_fore = 0.0, 0.84, -0.3, 0.0, 0.0, -1.0,0
+	node_stack_rack_aft = 0.0, -0.84, -0.3, 0.0, 0.0, -1.0,0
+
 	node_stack_roof = 0.0, 0.0, -1.025, 0.0, 0.0, -1.0,1
+	node_stack_roof_fore = 0.0, 0.84, -1.025, 0.0, 0.0, -1.0,0
+	node_stack_roof_aft = 0.0, -0.84, -1.025, 0.0, 0.0, -1.0,0
 	
 	node_stack_top2 = 0.0, 1.285, .4, 0.0, 1.0, 0.0,1
 	node_stack_bottom2 = 0.0, -1.285,.4, 0.0, -1.0, 0.0,1


### PR DESCRIPTION
The Karibou multi-hub has a "roof rack" with an attachment node in the middle, but the part is long enough that it can also fit several smaller objects (e.g. 0.625m) instead of one big object (e.g. 1.25m).  To make that easier, I've added a pair of additional attachment nodes to both the upper and lower levels of the roof rack, positioned ahead of and behind the one in the middle.

In addition to things like 0.625m parts, these nodes nicely fit three KIS container mounts in a row:

![karibou-3-attachments](https://cloud.githubusercontent.com/assets/23350503/24075921/c6708e22-0bfb-11e7-88a6-f6550c39d945.jpg)

(You can tell I like those things!)

Related: BobPalmer/Malemute#51