### PR TITLE
Fix input/output resources for Fertilizer(G) of MPU

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor250.cfg
@@ -465,7 +465,7 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio = 0.0006
+			Ratio = 0.00148
 			DumpExcess = False
 		}
 		INPUT_RESOURCE

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor375.cfg
@@ -469,17 +469,17 @@ PART
 		INPUT_RESOURCE
 		{
 			ResourceName = Gypsum
-			Ratio =  0.006
+			Ratio =  0.0064
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 12
+			Ratio = 9.574
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio = 0.0012
+			Ratio = 0.00315
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
@@ -490,7 +490,7 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Recyclables
-			Ratio = 0.00004
+			Ratio = 0.00001
 			DumpExcess = true
 		}
 		REQUIRED_RESOURCE

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Agriculture375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Agriculture375.cfg
@@ -431,7 +431,7 @@ PART
 		REQUIRED_RESOURCE
 		{
 			ResourceName = Organics
-			Ratio = 100
+			Ratio = 400
 		}
 	}			
 	


### PR DESCRIPTION
Values of resources for Fertilizer(G) convertors were a bit off. Especially Fertilizer outputs were lower then outputs from Fertilizer(M). I took values and their ratios from MPU-125 as a base and calculated new ones.